### PR TITLE
Typo corrections on uniface.h and Python wrapper

### DIFF
--- a/uniface.h
+++ b/uniface.h
@@ -919,7 +919,7 @@ public:
 
 			for( size_t i=0; i < peers.size(); i++ ) {
 				peers[i].set_current_t(curr_time.first);
-				peers[i].set_current_it(curr_time.second);
+				peers[i].set_current_sub(curr_time.second);
 			}
 		}
 
@@ -942,7 +942,7 @@ public:
 
 			for( size_t i=0; i < peers.size(); i++ ) {
 				peers[i].set_current_t(curr_time.first);
-				peers[i].set_current_it(curr_time.second);
+				peers[i].set_current_sub(curr_time.second);
 			}
 		}
 
@@ -968,7 +968,7 @@ public:
 
 			for( size_t i=0; i < peers.size(); i++ ) {
 				peers[i].set_current_t(curr_time.first);
-				peers[i].set_current_it(curr_time.second);
+				peers[i].set_current_sub(curr_time.second);
 			}
 		}
 
@@ -993,7 +993,7 @@ public:
 
 			for( size_t i=0; i<peers.size(); i++ ) {
 				peers[i].set_current_t(curr_time.first);
-				peers[i].set_current_it(curr_time.second);
+				peers[i].set_current_sub(curr_time.second);
 			}
 		}
 
@@ -1040,14 +1040,14 @@ private:
 	*/
 	void on_recv_confirm( int32_t sender, std::pair<time_type,iterator_type> timestamp ) {
 		peers[sender].set_current_t(timestamp.first);
-		peers[sender].set_current_it(timestamp.second);
+		peers[sender].set_current_sub(timestamp.second);
 	}
 
 	/** \brief Handles "forecast" messages
 	*/
 	void on_recv_forecast( int32_t sender, std::pair<time_type,iterator_type> timestamp ) {
 		peers[sender].set_next_t(timestamp.first);
-		peers[sender].set_next_it(timestamp.second);
+		peers[sender].set_next_sub(timestamp.second);
 	}
 
 	/** \brief Handles "data" messages

--- a/uniface.h
+++ b/uniface.h
@@ -123,7 +123,7 @@ private:
 	struct peer_state {
 		peer_state() : disable_send(false), disable_recv(false), ss_stat_send(false), ss_stat_recv(false) {}
 
-		using spans_type = std::map<std::pair<time_type,iterator_type>,span_t>;
+		using spans_type = std::map<std::pair<time_type,time_type>,span_t>;
 
 		bool is_recving(time_type t, const span_t& s) const {
 			return scan_spans_(t,s,recving_spans);

--- a/wrappers/Python/mui4py/__init__.py
+++ b/wrappers/Python/mui4py/__init__.py
@@ -5,8 +5,8 @@ from mui4py.samplers import SamplerExact, SamplerGauss, SamplerMovingAverage,\
                             SamplerNearestNeighbor, SamplerPseudoNearest2Linear,\
                             SamplerPseudoNearestNeighbor, SamplerSherpardQuintic,\
                             SamplerSphQuintic, SamplerSumQuintic, SamplerRbf,\
-                            ChronoSamplerExact, ChronoSamplerGauss,\
-                            ChronoSamplerMean, ChronoSamplerSum
+                            TemporalSamplerExact, TemporalSamplerGauss,\
+                            TemporalSamplerMean, TemporalSamplerSum
 from mui4py.types import STRING, INT32, INT64, INT, FLOAT32, FLOAT64, FLOAT
 from mui4py.config import Config, set_default_config, get_default_config
 import mui4py.geometry

--- a/wrappers/Python/mui4py/mui4py.cpp
+++ b/wrappers/Python/mui4py/mui4py.cpp
@@ -404,7 +404,7 @@ DECLARE_FUNC_HEADER(uniface) {
     .def("barrier", (void (Tclass::*)(Ttime)) &Tclass::barrier, "")
     .def("barrier", (void (Tclass::*)(Ttime, Titer)) &Tclass::barrier, "")
     .def("forget", (void (Tclass::*)(Ttime, bool)) &Tclass::forget, "")
-    .def("forget", (void (Tclass::*)(Ttime, Titer, bool)) &Tclass::forget, "")
+    .def("forget", (void (Tclass::*)(std::pair<Ttime, Titer>, bool)) &Tclass::forget, "")
     .def("set_memory", (void (Tclass::*)(Ttime)) &Tclass::set_memory, "")
     .def("announce_send_span", (void (Tclass::*)(Ttime, Ttime, mui::geometry::any_shape<Tconfig>, bool synchronised))\
            &Tclass::announce_send_span,"") 

--- a/wrappers/Python/mui4py/mui4py.py
+++ b/wrappers/Python/mui4py/mui4py.py
@@ -155,7 +155,7 @@ class Uniface(CppClass):
             self.raw.is_ready(attr, t1)
 
     def set_memory(self, t):
-        self.raw.set_memmory(t)
+        self.raw.set_memory(t)
 
     def assign(self, tag, val):
         data_type = map_type[self._get_tag_type(tag)]

--- a/wrappers/Python/mui4py/mui4py.py
+++ b/wrappers/Python/mui4py/mui4py.py
@@ -133,8 +133,8 @@ class Uniface(CppClass):
         push_fname, data_type = self._get_pushfname("push_many_", tag, type_in=values.dtype.type)
         getattr(self.raw, push_fname)(tag, points, values)
 
-    def commit(self, tstamp):
-        return self.raw.commit(tstamp)
+    def commit(self, tstamp, iterstamp=0):
+        return self.raw.commit(tstamp,iterstamp)
 
     def barrier(self, t1, t2=None):
         if t2 is not None:

--- a/wrappers/Python/mui4py/samplers.py
+++ b/wrappers/Python/mui4py/samplers.py
@@ -2,7 +2,7 @@ from mui4py.common import CppClass
 from mui4py.config import Config
 from mui4py.types import *
 
-# Inteface for Sampler and ChronoSampler
+# Inteface for Sampler and TemporalSampler
 def sampler_fetch_signature(self):
     sig = self._split_class_name(title=False)
     sig = sig.replace("_sampler", "")
@@ -70,28 +70,28 @@ class SamplerRbf(Sampler, CppClass):
             self._ALLOWED_IO_TYPES = [INT32, INT64, FLOAT32, FLOAT64]
 
 # Chrono samplers
-class ChronoSampler(CppClass):
+class TemporalSampler(CppClass):
     def __init__(self, args=(), kwargs={}):
         # Empty config to not trigger error in default config.
-        super(ChronoSampler, self).__init__(Config(), args, kwargs)
-ChronoSampler.fetch_signature = sampler_fetch_signature
+        super(TemporalSampler, self).__init__(Config(), args, kwargs)
+TemporalSampler.fetch_signature = sampler_fetch_signature
 
-class ChronoSamplerExact(ChronoSampler):
+class TemporalSamplerExact(TemporalSampler):
     def __init__(self, tol=None):
-        super(ChronoSamplerExact, self).__init__(kwargs={"tol": tol})
+        super(TemporalSamplerExact, self).__init__(kwargs={"tol": tol})
         self._ALLOWED_IO_TYPES = [INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64, STRING]
 
-class ChronoSamplerGauss(ChronoSampler):
+class TemporalSamplerGauss(TemporalSampler):
     def __init__(self, cutoff, sigma):
-        super(ChronoSamplerGauss, self).__init__(args=(cutoff, sigma))
+        super(TemporalSamplerGauss, self).__init__(args=(cutoff, sigma))
         self._ALLOWED_IO_TYPES = [INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]
 
-class ChronoSamplerMean(ChronoSampler):
+class TemporalSamplerMean(TemporalSampler):
     def __init__(self, newleft=None, newright=None):
-        super(ChronoSamplerMean, self).__init__(kwargs={"newleft": newleft, "newright": newright})
+        super(TemporalSamplerMean, self).__init__(kwargs={"newleft": newleft, "newright": newright})
         self._ALLOWED_IO_TYPES = [INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]
 
-class ChronoSamplerSum(ChronoSampler):
+class TemporalSamplerSum(TemporalSampler):
     def __init__(self, newleft=None, newright=None):
-        super(ChronoSamplerSum, self).__init__(kwargs={"newleft": newleft, "newright": newright})
+        super(TemporalSamplerSum, self).__init__(kwargs={"newleft": newleft, "newright": newright})
         self._ALLOWED_IO_TYPES = [INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]


### PR DESCRIPTION
I haven't finished the Python wrapper update with the iterator_type. I'm going to send you an email with the details.

What has been done in this pull request:

1. Some typo correction on uniface.h
      Please double-confirm the "spans_type" one. If I understand correctly, the std::pair is for <time_on, time_off>. Therefore, it should be std::pair<time_type,time_type>.
      Other corrections in uniface.h are straightforward.
2. Initial update on Python wrapper. More updates towards the new iterator_type will be in the subsequent pull requests.