### PR TITLE
Staged pull request on MUI Python Wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 Debug
 Release
 build
+src/linear_algebra/test/matrix
+src/linear_algebra/test/matrix.csv
+src/linear_algebra/test/solver

--- a/src/samplers/algorithm/algo_fixed_relaxation.h
+++ b/src/samplers/algorithm/algo_fixed_relaxation.h
@@ -271,13 +271,13 @@ public:
                     return calculate_relaxed_value(filtered_value,filtered_old_value);
 
             }
-
+            return calculate_relaxed_value(filtered_value,filtered_old_value);
         }
     }
 
 private:
     template<typename OTYPE>
-    OTYPE calculate_relaxed_value(OTYPE filtered_value, OTYPE filtered_old_value) {
+    OTYPE calculate_relaxed_value(OTYPE filtered_value, OTYPE filtered_old_value) const {
 
         return (under_relaxation_factor_ * filtered_value) + ((1 - under_relaxation_factor_) * filtered_old_value);
 

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -44,7 +44,8 @@ pybind11_add_module(mui4py_mod MODULE
   mui4py/cpp/mui4py.cpp
   mui4py/cpp/sampler.cpp
   mui4py/cpp/temporal_sampler.cpp
-  mui4py/cpp/geometry.cpp)
+  mui4py/cpp/geometry.cpp
+  mui4py/cpp/uniface.cpp)
 
 target_include_directories(mui4py_mod PRIVATE ${MPI_INCLUDE_PATH} ../..)
 target_compile_definitions(mui4py_mod PRIVATE PYTHON_BINDINGS PYTHON_INT_${NUMPY_INT_SIZE})

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -6,6 +6,7 @@ project(mui4py)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_INCLUDE_DIRECTORIES})
 
 # Development component which includes both Development.Module and
 # Development.Embed is not required for building a Python module.  Correct

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -45,7 +45,12 @@ pybind11_add_module(mui4py_mod MODULE
   mui4py/cpp/sampler.cpp
   mui4py/cpp/temporal_sampler.cpp
   mui4py/cpp/geometry.cpp
-  mui4py/cpp/uniface.cpp)
+  mui4py/cpp/uniface1d.cpp
+  mui4py/cpp/uniface2d.cpp
+  mui4py/cpp/uniface3d.cpp
+  mui4py/cpp/uniface1f.cpp
+  mui4py/cpp/uniface2f.cpp
+  mui4py/cpp/uniface3f.cpp)
 
 target_include_directories(mui4py_mod PRIVATE ${MPI_INCLUDE_PATH} ../..)
 target_compile_definitions(mui4py_mod PRIVATE PYTHON_BINDINGS PYTHON_INT_${NUMPY_INT_SIZE})

--- a/wrappers/Python/README.md
+++ b/wrappers/Python/README.md
@@ -14,11 +14,21 @@
 
 ## Installation
 The easiest way to install the python package is to use:
+
 ```
 pip3 install .
 ```
+
 Alternatively `python3 setup.py install` may work.
-The C++ Python bindings can also be built directly with cmake and make, which is useful for testing.
+
+
+The C++ Python bindings can also be built directly with cmake and make, which is useful for testing:
+
+```
+cmake -DPython3_EXECUTABLE=/path/to/python3 -DCMAKE_PREFIX_PATH=/path/to/pybind11 -DCMAKE_INCLUDE_DIRECTORIES=/path/to/MUI/src .
+make
+export PYTHONPATH=/path/to/MUI/wrappers/Python
+```
 
 ### General
 

--- a/wrappers/Python/README.md
+++ b/wrappers/Python/README.md
@@ -13,21 +13,42 @@
 # Building
 
 ## Installation
-The easiest way to install the python package is to use:
+- The easiest way to install the Python package is to use:
 
 ```
 pip3 install .
 ```
-
-Alternatively `python3 setup.py install` may work.
-
-
-The C++ Python bindings can also be built directly with cmake and make, which is useful for testing:
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;In the event that CMake encounter an error related to `mui.h` not being found during compilation, you can resolve this by adding the following flag to the CMAKE_ARGS:
 
 ```
-cmake -DPython3_EXECUTABLE=/path/to/python3 -DCMAKE_PREFIX_PATH=/path/to/pybind11 -DCMAKE_INCLUDE_DIRECTORIES=/path/to/MUI/src .
+-DCMAKE_INCLUDE_DIRECTORIES=/path/to/MUI/src
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;In the event that CMake is unable to locate Python3 or is unable to find the correct version of Python3, you can use the following flag to the CMAKE_ARGS to specify the path to the correct Python3 executable:
+
+```
+-DPython3_EXECUTABLE=/path/to/python3
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;If CMake is unable to locate pybind11 during the compilation process, you can use the following flag to the CMAKE_ARGS to specify the path to the pybind11 directory:
+
+```
+-DCMAKE_PREFIX_PATH=/path/to/pybind11
+```
+
+- Alternatively `python3 setup.py install` may work.
+
+
+- The C++ Python bindings can also be built directly with cmake and make, which is useful for testing. An example of built with cmake and make:
+
+```
+mkdir build && cd build
+cmake ..
 make
-export PYTHONPATH=/path/to/MUI/wrappers/Python
+cd .. && cp build/*.so mui4py/
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Note that if built with cmake and make, the path to the MUI Python wrapper should be added to the PYTHONPATH before use:
+
+```
+export PYTHONPATH=$PYTHONPATH:/path/to/MUI/wrappers/Python
 ```
 
 ### General

--- a/wrappers/Python/mui4py/__init__.py
+++ b/wrappers/Python/mui4py/__init__.py
@@ -1,3 +1,4 @@
+"""
 ##############################################################################
 # Multiscale Universal Interface Code Coupling Library                       #
 #                                                                            #
@@ -42,6 +43,7 @@
 # @date 25 January 2019
 # @brief Marker file denotes the directory containing the file as the MUI Python wrapper package.
 #
+"""
 
 # flake8: noqa
 from mui4py.mui4py import Uniface, mpi_split_by_app, set_quiet,\

--- a/wrappers/Python/mui4py/__init__.py
+++ b/wrappers/Python/mui4py/__init__.py
@@ -2,7 +2,7 @@
 ##############################################################################
 # Multiscale Universal Interface Code Coupling Library                       #
 #                                                                            #
-# Copyright (C) 2023 E. R. Fernandez                                         #
+# Copyright (C) 2023 E. R. Fernandez, W. Liu                                 #
 #                                                                            #
 # This software is jointly licensed under the Apache License, Version 2.0    #
 # and the GNU General Public License version 3, you may use it according     #
@@ -39,7 +39,7 @@
 ##############################################################################
 #
 # @file __init__.py
-# @author E. R. Fernandez
+# @author E. R. Fernandez, W. Liu
 # @date 25 January 2019
 # @brief Marker file denotes the directory containing the file as the MUI Python wrapper package.
 #
@@ -55,6 +55,6 @@ from mui4py.samplers import SamplerExact, SamplerGauss, SamplerMovingAverage,\
                             SamplerSphQuintic, SamplerSumQuintic, SamplerRbf,\
                             TemporalSamplerExact, TemporalSamplerGauss,\
                             TemporalSamplerMean, TemporalSamplerSum
-from mui4py.types import STRING, INT32, INT64, INT, UINT32, UINT64, UINT, FLOAT32, FLOAT64, FLOAT
+from mui4py.types import STRING, INT32, INT64, INT, UINT32, UINT64, UINT, FLOAT32, FLOAT64, FLOAT, BOOL
 from mui4py.config import Config, set_default_config, get_default_config
 import mui4py.geometry

--- a/wrappers/Python/mui4py/__init__.py
+++ b/wrappers/Python/mui4py/__init__.py
@@ -1,3 +1,48 @@
+##############################################################################
+# Multiscale Universal Interface Code Coupling Library                       #
+#                                                                            #
+# Copyright (C) 2023 E. R. Fernandez                                         #
+#                                                                            #
+# This software is jointly licensed under the Apache License, Version 2.0    #
+# and the GNU General Public License version 3, you may use it according     #
+# to either.                                                                 #
+#                                                                            #
+# ** Apache License, version 2.0 **                                          #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License");            #
+# you may not use this file except in compliance with the License.           #
+# You may obtain a copy of the License at                                    #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#                                                                            #
+# ** GNU General Public License, version 3 **                                #
+#                                                                            #
+# This program is free software: you can redistribute it and/or modify       #
+# it under the terms of the GNU General Public License as published by       #
+# the Free Software Foundation, either version 3 of the License, or          #
+# (at your option) any later version.                                        #
+#                                                                            #
+# This program is distributed in the hope that it will be useful,            #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              #
+# GNU General Public License for more details.                               #
+#                                                                            #
+# You should have received a copy of the GNU General Public License          #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.      #
+##############################################################################
+#
+# @file __init__.py
+# @author E. R. Fernandez
+# @date 25 January 2019
+# @brief Marker file denotes the directory containing the file as the MUI Python wrapper package.
+#
+
 # flake8: noqa
 from mui4py.mui4py import Uniface, mpi_split_by_app, set_quiet,\
                           set_data_types_unifaces, create_unifaces,\

--- a/wrappers/Python/mui4py/common.py
+++ b/wrappers/Python/mui4py/common.py
@@ -1,3 +1,4 @@
+"""
 ##############################################################################
 # Multiscale Universal Interface Code Coupling Library                       #
 #                                                                            #
@@ -42,6 +43,7 @@
 # @date 25 January 2019
 # @brief Common functions for MUI Python wrapper.
 #
+"""
 
 import mui4py.mui4py_mod as mui4py_mod
 from mui4py.config import get_default_config

--- a/wrappers/Python/mui4py/common.py
+++ b/wrappers/Python/mui4py/common.py
@@ -1,3 +1,48 @@
+##############################################################################
+# Multiscale Universal Interface Code Coupling Library                       #
+#                                                                            #
+# Copyright (C) 2023 E. R. Fernandez                                         #
+#                                                                            #
+# This software is jointly licensed under the Apache License, Version 2.0    #
+# and the GNU General Public License version 3, you may use it according     #
+# to either.                                                                 #
+#                                                                            #
+# ** Apache License, version 2.0 **                                          #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License");            #
+# you may not use this file except in compliance with the License.           #
+# You may obtain a copy of the License at                                    #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#                                                                            #
+# ** GNU General Public License, version 3 **                                #
+#                                                                            #
+# This program is free software: you can redistribute it and/or modify       #
+# it under the terms of the GNU General Public License as published by       #
+# the Free Software Foundation, either version 3 of the License, or          #
+# (at your option) any later version.                                        #
+#                                                                            #
+# This program is distributed in the hope that it will be useful,            #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              #
+# GNU General Public License for more details.                               #
+#                                                                            #
+# You should have received a copy of the GNU General Public License          #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.      #
+##############################################################################
+#
+# @file common.py
+# @author E. R. Fernandez
+# @date 25 January 2019
+# @brief Common functions for MUI Python wrapper.
+#
+
 import mui4py.mui4py_mod as mui4py_mod
 from mui4py.config import get_default_config
 from mui4py.types import map_type, get_float_type_str, get_int_type_str, get_io_type_str

--- a/wrappers/Python/mui4py/common.py
+++ b/wrappers/Python/mui4py/common.py
@@ -59,10 +59,10 @@ class CppClass(object):
         self.raw_point = None
         self.raw = None
         self.io_data_type = None
-        # Convertir args en Args()
+        # Convert args to Args()
         self.args = tuple([Arg(a) if not issubclass(a.__class__, Arg) else a for a in args])
         self.namespace = ""
-        # Filter None-valued entries to gake C++ default values.
+        # Filter None-valued entries to take C++ default values.
         self.kwargs = {k: v for k, v in kwargs.items() if v is not None}
         self.configured = False
         self._ALLOWED_IO_TYPES = None

--- a/wrappers/Python/mui4py/config.py
+++ b/wrappers/Python/mui4py/config.py
@@ -1,3 +1,4 @@
+"""
 ##############################################################################
 # Multiscale Universal Interface Code Coupling Library                       #
 #                                                                            #
@@ -42,6 +43,7 @@
 # @date 25 January 2019
 # @brief Configure functions for MUI Python wrapper.
 #
+"""
 
 from mui4py.types import map_type, UINT
 __default_config = None

--- a/wrappers/Python/mui4py/config.py
+++ b/wrappers/Python/mui4py/config.py
@@ -1,3 +1,48 @@
+##############################################################################
+# Multiscale Universal Interface Code Coupling Library                       #
+#                                                                            #
+# Copyright (C) 2023 E. R. Fernandez                                         #
+#                                                                            #
+# This software is jointly licensed under the Apache License, Version 2.0    #
+# and the GNU General Public License version 3, you may use it according     #
+# to either.                                                                 #
+#                                                                            #
+# ** Apache License, version 2.0 **                                          #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License");            #
+# you may not use this file except in compliance with the License.           #
+# You may obtain a copy of the License at                                    #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#                                                                            #
+# ** GNU General Public License, version 3 **                                #
+#                                                                            #
+# This program is free software: you can redistribute it and/or modify       #
+# it under the terms of the GNU General Public License as published by       #
+# the Free Software Foundation, either version 3 of the License, or          #
+# (at your option) any later version.                                        #
+#                                                                            #
+# This program is distributed in the hope that it will be useful,            #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              #
+# GNU General Public License for more details.                               #
+#                                                                            #
+# You should have received a copy of the GNU General Public License          #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.      #
+##############################################################################
+#
+# @file config.py
+# @author E. R. Fernandez
+# @date 25 January 2019
+# @brief Configure functions for MUI Python wrapper.
+#
+
 from mui4py.types import map_type, UINT
 __default_config = None
 

--- a/wrappers/Python/mui4py/cpp/compiler_info.h
+++ b/wrappers/Python/mui4py/cpp/compiler_info.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -38,54 +38,35 @@
 *****************************************************************************/
 
 /**
- * @file mui4py.cpp
- * @author C. Richardson, E. R. Fernandez
- * @date 20 January 2023
- * @brief Main c++ file for MUI Python wrapper.
+ * @file compiler_info.h
+ * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @date 11 March 2023
+ * @brief Compiler info and MUI version for MUI Python wrapper.
  */
 
-#include <mui.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <mpi4py/mpi4py.h>
-#include <string>
-
-#include "config_name.h"
-#include "compiler_info.h"
-#include "sampler_name.h"
-#include "temporal_name.h"
-
-// Declaration of other files
-void temporal_sampler(py::module &m);
-void sampler(py::module &m);
-void geometry(py::module &m);
-void uniface(py::module &m);
-
-PYBIND11_MODULE(mui4py_mod, m)
+std::string get_mpi_version()
 {
-  m.doc() = "MUI bindings for Python.";
+#ifdef MPI_VERSION_STR
+  return MPI_VERSION_STR;
+#else
+  return "";
+#endif
+}
 
-  // Expose numerical limits from C++
-  m.attr("numeric_limits_real") = std::numeric_limits<double>::min();
-  m.attr("numeric_limits_int") = std::numeric_limits<int>::min();
+std::string get_compiler_version()
+{
+#ifdef COMPILER_VERSION_STR
+  return COMPILER_VERSION_STR;
+#else
+  return "";
+#endif
+}
 
-  geometry(m);
-  sampler(m);
-  temporal_sampler(m);
-  uniface(m);
-
-  m.def("set_quiet", &mui::set_quiet, "");
-  m.def(
-      "mpi_split_by_app", []() -> py::handle
-      {
-    if (import_mpi4py() < 0)
-      Py_RETURN_NONE;
-    return PyMPIComm_New(mui::mpi_split_by_app()); },
-      "");
-  m.def("get_mpi_version", &get_mpi_version, "");
-  m.def("get_compiler_config", &get_compiler_config, "");
-  m.def("get_compiler_version", &get_compiler_version, "");
+std::string get_compiler_config()
+{
+#ifdef COMPILER_CONFIG_STR
+  return COMPILER_CONFIG_STR;
+#else
+  return "";
+#endif
 }

--- a/wrappers/Python/mui4py/cpp/config_name.h
+++ b/wrappers/Python/mui4py/cpp/config_name.h
@@ -1,5 +1,50 @@
+/*****************************************************************************
+* Multiscale Universal Interface Code Coupling Library                       *
+*                                                                            *
+* Copyright (C) 2023 C. Richardson                                           *
+*                                                                            *
+* This software is jointly licensed under the Apache License, Version 2.0    *
+* and the GNU General Public License version 3, you may use it according     *
+* to either.                                                                 *
+*                                                                            *
+* ** Apache License, version 2.0 **                                          *
+*                                                                            *
+* Licensed under the Apache License, Version 2.0 (the "License");            *
+* you may not use this file except in compliance with the License.           *
+* You may obtain a copy of the License at                                    *
+*                                                                            *
+* http://www.apache.org/licenses/LICENSE-2.0                                 *
+*                                                                            *
+* Unless required by applicable law or agreed to in writing, software        *
+* distributed under the License is distributed on an "AS IS" BASIS,          *
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+* See the License for the specific language governing permissions and        *
+* limitations under the License.                                             *
+*                                                                            *
+* ** GNU General Public License, version 3 **                                *
+*                                                                            *
+* This program is free software: you can redistribute it and/or modify       *
+* it under the terms of the GNU General Public License as published by       *
+* the Free Software Foundation, either version 3 of the License, or          *
+* (at your option) any later version.                                        *
+*                                                                            *
+* This program is distributed in the hope that it will be useful,            *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+* GNU General Public License for more details.                               *
+*                                                                            *
+* You should have received a copy of the GNU General Public License          *
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
+*****************************************************************************/
 
-#include "../../../../src/mui.h"
+/**
+ * @file config_name.h
+ * @author C. Richardson
+ * @date 20 January 2023
+ * @brief Config names for MUI Python wrapper.
+ */
+
+#include <mui.h>
 #include <string>
 
 template <typename CONFIG>

--- a/wrappers/Python/mui4py/cpp/config_name.h
+++ b/wrappers/Python/mui4py/cpp/config_name.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson                                           *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file config_name.h
- * @author C. Richardson
+ * @author C. Richardson, E. R. Fernandez
  * @date 20 January 2023
  * @brief Config names for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/config_name.h
+++ b/wrappers/Python/mui4py/cpp/config_name.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson                                           *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file config_name.h
- * @author C. Richardson, E. R. Fernandez
+ * @author C. Richardson
  * @date 20 January 2023
  * @brief Config names for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/geometry.cpp
+++ b/wrappers/Python/mui4py/cpp/geometry.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson                                           *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file geometry.cpp
- * @author C. Richardson, E. R. Fernandez
+ * @author C. Richardson
  * @date 20 January 2023
  * @brief Geometries for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/geometry.cpp
+++ b/wrappers/Python/mui4py/cpp/geometry.cpp
@@ -1,5 +1,50 @@
+/*****************************************************************************
+* Multiscale Universal Interface Code Coupling Library                       *
+*                                                                            *
+* Copyright (C) 2023 C. Richardson                                           *
+*                                                                            *
+* This software is jointly licensed under the Apache License, Version 2.0    *
+* and the GNU General Public License version 3, you may use it according     *
+* to either.                                                                 *
+*                                                                            *
+* ** Apache License, version 2.0 **                                          *
+*                                                                            *
+* Licensed under the Apache License, Version 2.0 (the "License");            *
+* you may not use this file except in compliance with the License.           *
+* You may obtain a copy of the License at                                    *
+*                                                                            *
+* http://www.apache.org/licenses/LICENSE-2.0                                 *
+*                                                                            *
+* Unless required by applicable law or agreed to in writing, software        *
+* distributed under the License is distributed on an "AS IS" BASIS,          *
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+* See the License for the specific language governing permissions and        *
+* limitations under the License.                                             *
+*                                                                            *
+* ** GNU General Public License, version 3 **                                *
+*                                                                            *
+* This program is free software: you can redistribute it and/or modify       *
+* it under the terms of the GNU General Public License as published by       *
+* the Free Software Foundation, either version 3 of the License, or          *
+* (at your option) any later version.                                        *
+*                                                                            *
+* This program is distributed in the hope that it will be useful,            *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+* GNU General Public License for more details.                               *
+*                                                                            *
+* You should have received a copy of the GNU General Public License          *
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
+*****************************************************************************/
 
-#include "../../../../src/mui.h"
+/**
+ * @file geometry.cpp
+ * @author C. Richardson
+ * @date 20 January 2023
+ * @brief Geometries for MUI Python wrapper.
+ */
+
+#include <mui.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>

--- a/wrappers/Python/mui4py/cpp/geometry.cpp
+++ b/wrappers/Python/mui4py/cpp/geometry.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson                                           *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file geometry.cpp
- * @author C. Richardson
+ * @author C. Richardson, E. R. Fernandez
  * @date 20 January 2023
  * @brief Geometries for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/mui4py.cpp
+++ b/wrappers/Python/mui4py/cpp/mui4py.cpp
@@ -53,10 +53,7 @@
 #include <mpi4py/mpi4py.h>
 #include <string>
 
-#include "config_name.h"
 #include "compiler_info.h"
-#include "sampler_name.h"
-#include "temporal_name.h"
 
 // Declaration of other files
 void temporal_sampler(py::module &m);

--- a/wrappers/Python/mui4py/cpp/mui4py.cpp
+++ b/wrappers/Python/mui4py/cpp/mui4py.cpp
@@ -1,3 +1,48 @@
+/*****************************************************************************
+* Multiscale Universal Interface Code Coupling Library                       *
+*                                                                            *
+* Copyright (C) 2023 C. Richardson                                           *
+*                                                                            *
+* This software is jointly licensed under the Apache License, Version 2.0    *
+* and the GNU General Public License version 3, you may use it according     *
+* to either.                                                                 *
+*                                                                            *
+* ** Apache License, version 2.0 **                                          *
+*                                                                            *
+* Licensed under the Apache License, Version 2.0 (the "License");            *
+* you may not use this file except in compliance with the License.           *
+* You may obtain a copy of the License at                                    *
+*                                                                            *
+* http://www.apache.org/licenses/LICENSE-2.0                                 *
+*                                                                            *
+* Unless required by applicable law or agreed to in writing, software        *
+* distributed under the License is distributed on an "AS IS" BASIS,          *
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+* See the License for the specific language governing permissions and        *
+* limitations under the License.                                             *
+*                                                                            *
+* ** GNU General Public License, version 3 **                                *
+*                                                                            *
+* This program is free software: you can redistribute it and/or modify       *
+* it under the terms of the GNU General Public License as published by       *
+* the Free Software Foundation, either version 3 of the License, or          *
+* (at your option) any later version.                                        *
+*                                                                            *
+* This program is distributed in the hope that it will be useful,            *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+* GNU General Public License for more details.                               *
+*                                                                            *
+* You should have received a copy of the GNU General Public License          *
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
+*****************************************************************************/
+
+/**
+ * @file mui4py.cpp
+ * @author C. Richardson
+ * @date 20 January 2023
+ * @brief Main c++ file for MUI Python wrapper.
+ */
 
 #include <mui.h>
 #include <pybind11/chrono.h>

--- a/wrappers/Python/mui4py/cpp/mui4py.cpp
+++ b/wrappers/Python/mui4py/cpp/mui4py.cpp
@@ -1,5 +1,5 @@
 
-#include "../../../../src/mui.h"
+#include <mui.h>
 #include <pybind11/chrono.h>
 #include <pybind11/functional.h>
 #include <pybind11/numpy.h>

--- a/wrappers/Python/mui4py/cpp/mui4py.cpp
+++ b/wrappers/Python/mui4py/cpp/mui4py.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson                                           *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file mui4py.cpp
- * @author C. Richardson
+ * @author C. Richardson, E. R. Fernandez
  * @date 20 January 2023
  * @brief Main c++ file for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/mui4py.cpp
+++ b/wrappers/Python/mui4py/cpp/mui4py.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file mui4py.cpp
- * @author C. Richardson, E. R. Fernandez
+ * @author C. Richardson, E. R. Fernandez, W. Liu
  * @date 20 January 2023
  * @brief Main c++ file for MUI Python wrapper.
  */
@@ -73,6 +73,7 @@ PYBIND11_MODULE(mui4py_mod, m)
   // Expose numerical limits from C++
   m.attr("numeric_limits_real") = std::numeric_limits<double>::min();
   m.attr("numeric_limits_int") = std::numeric_limits<int>::min();
+  m.attr("numeric_limits_uint") = std::numeric_limits<unsigned int>::lowest();
 
   geometry(m);
   sampler(m);

--- a/wrappers/Python/mui4py/cpp/sampler.cpp
+++ b/wrappers/Python/mui4py/cpp/sampler.cpp
@@ -1,5 +1,50 @@
+/*****************************************************************************
+* Multiscale Universal Interface Code Coupling Library                       *
+*                                                                            *
+* Copyright (C) 2023 C. Richardson                                           *
+*                                                                            *
+* This software is jointly licensed under the Apache License, Version 2.0    *
+* and the GNU General Public License version 3, you may use it according     *
+* to either.                                                                 *
+*                                                                            *
+* ** Apache License, version 2.0 **                                          *
+*                                                                            *
+* Licensed under the Apache License, Version 2.0 (the "License");            *
+* you may not use this file except in compliance with the License.           *
+* You may obtain a copy of the License at                                    *
+*                                                                            *
+* http://www.apache.org/licenses/LICENSE-2.0                                 *
+*                                                                            *
+* Unless required by applicable law or agreed to in writing, software        *
+* distributed under the License is distributed on an "AS IS" BASIS,          *
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+* See the License for the specific language governing permissions and        *
+* limitations under the License.                                             *
+*                                                                            *
+* ** GNU General Public License, version 3 **                                *
+*                                                                            *
+* This program is free software: you can redistribute it and/or modify       *
+* it under the terms of the GNU General Public License as published by       *
+* the Free Software Foundation, either version 3 of the License, or          *
+* (at your option) any later version.                                        *
+*                                                                            *
+* This program is distributed in the hope that it will be useful,            *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+* GNU General Public License for more details.                               *
+*                                                                            *
+* You should have received a copy of the GNU General Public License          *
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
+*****************************************************************************/
 
-#include "../../../../src/mui.h"
+/**
+ * @file sampler.cpp
+ * @author C. Richardson
+ * @date 20 January 2023
+ * @brief Samplers for MUI Python wrapper.
+ */
+
+#include <mui.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
@@ -203,26 +248,26 @@ void declare_sampler_sum_quintic(py::module &m)
 }
 
 // SPATIAL_SAMPLER_RBF CLASS//
-template <typename Tconfig, typename T>
-void declare_sampler_rbf_t(py::module &m)
-{
-    std::string name = "_Sampler_rbf" + config_name<Tconfig>() + "_" + type_name<T>();
-    using Treal = typename Tconfig::REAL;
-    using Tint = typename Tconfig::INT;
-    using Tpoint = typename Tconfig::point_type;
-    using Tclass = mui::sampler_rbf<Tconfig, T, T>;
-    py::class_<Tclass>(m, name.c_str()).def(py::init<Treal, std::vector<Tpoint> &, Tint,
-    		bool, bool, Treal, Treal, Tint, Tint, Tint, PyMPIComm_New(MPI_Comm)>());
-}
-
-template <typename Tconfig>
-void declare_sampler_rbf(py::module &m)
-{
-    declare_sampler_rbf_t<Tconfig, double>(m);
-    declare_sampler_rbf_t<Tconfig, float>(m);
-    declare_sampler_rbf_t<Tconfig, std::int32_t>(m);
-    declare_sampler_rbf_t<Tconfig, std::int64_t>(m);
-}
+//template <typename Tconfig, typename T>
+//void declare_sampler_rbf_t(py::module &m)
+//{
+//    std::string name = "_Sampler_rbf" + config_name<Tconfig>() + "_" + type_name<T>();
+//    using Treal = typename Tconfig::REAL;
+//    using Tint = typename Tconfig::INT;
+//    using Tpoint = typename Tconfig::point_type;
+//    using Tclass = mui::sampler_rbf<Tconfig, T, T>;
+//    py::class_<Tclass>(m, name.c_str()).def(py::init<Treal, std::vector<Tpoint> &, Tint,
+//    		bool, bool, Treal, Treal, Tint, Tint, Tint, PyMPIComm_New(MPI_Comm)>());
+//}
+//
+//template <typename Tconfig>
+//void declare_sampler_rbf(py::module &m)
+//{
+//    declare_sampler_rbf_t<Tconfig, double>(m);
+//    declare_sampler_rbf_t<Tconfig, float>(m);
+//    declare_sampler_rbf_t<Tconfig, std::int32_t>(m);
+//    declare_sampler_rbf_t<Tconfig, std::int64_t>(m);
+//}
 
 template <typename Tconfig>
 void declare_samplers(py::module &m)
@@ -238,7 +283,7 @@ void declare_samplers(py::module &m)
     declare_sampler_shepard_quintic<Tconfig>(m);
     declare_sampler_sph_quintic<Tconfig>(m);
     declare_sampler_sum_quintic<Tconfig>(m);
-    declare_sampler_rbf<Tconfig>(m);
+    //declare_sampler_rbf<Tconfig>(m);
 }
 
 void sampler(py::module &m)

--- a/wrappers/Python/mui4py/cpp/sampler.cpp
+++ b/wrappers/Python/mui4py/cpp/sampler.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson                                           *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file sampler.cpp
- * @author C. Richardson
+ * @author C. Richardson, E. R. Fernandez
  * @date 20 January 2023
  * @brief Samplers for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/sampler_name.h
+++ b/wrappers/Python/mui4py/cpp/sampler_name.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -38,54 +38,32 @@
 *****************************************************************************/
 
 /**
- * @file mui4py.cpp
- * @author C. Richardson, E. R. Fernandez
- * @date 20 January 2023
- * @brief Main c++ file for MUI Python wrapper.
+ * @file sampler_name.h
+ * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @date 11 March 2023
+ * @brief Spacial sampler names for MUI Python wrapper.
  */
 
-#include <mui.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <mpi4py/mpi4py.h>
-#include <string>
-
-#include "config_name.h"
-#include "compiler_info.h"
-#include "sampler_name.h"
-#include "temporal_name.h"
-
-// Declaration of other files
-void temporal_sampler(py::module &m);
-void sampler(py::module &m);
-void geometry(py::module &m);
-void uniface(py::module &m);
-
-PYBIND11_MODULE(mui4py_mod, m)
+template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler>
+std::string sampler_name()
 {
-  m.doc() = "MUI bindings for Python.";
-
-  // Expose numerical limits from C++
-  m.attr("numeric_limits_real") = std::numeric_limits<double>::min();
-  m.attr("numeric_limits_int") = std::numeric_limits<int>::min();
-
-  geometry(m);
-  sampler(m);
-  temporal_sampler(m);
-  uniface(m);
-
-  m.def("set_quiet", &mui::set_quiet, "");
-  m.def(
-      "mpi_split_by_app", []() -> py::handle
-      {
-    if (import_mpi4py() < 0)
-      Py_RETURN_NONE;
-    return PyMPIComm_New(mui::mpi_split_by_app()); },
-      "");
-  m.def("get_mpi_version", &get_mpi_version, "");
-  m.def("get_compiler_config", &get_compiler_config, "");
-  m.def("get_compiler_version", &get_compiler_version, "");
+  if (std::is_same<Tsampler<Tconfig, T, T>, mui::sampler_exact<Tconfig, T, T>>::value)
+    return "exact";
+  if (std::is_same<Tsampler<Tconfig, T, T>, mui::sampler_gauss<Tconfig, T, T>>::value)
+    return "gauss";
+  if (std::is_same<Tsampler<Tconfig, T, T>, mui::sampler_moving_average<Tconfig, T, T>>::value)
+    return "moving_average";
+  if (std::is_same<Tsampler<Tconfig, T, T>, mui::sampler_nearest_neighbor<Tconfig, T, T>>::value)
+    return "nearest_neighbor";
+  if (std::is_same<Tsampler<Tconfig, T, T>, mui::sampler_pseudo_n2_linear<Tconfig, T, T>>::value)
+    return "pseudo_n2_linear";
+  if (std::is_same<Tsampler<Tconfig, T, T>, mui::sampler_pseudo_nearest_neighbor<Tconfig, T, T>>::value)
+    return "pseudo_nearest_neighbor";
+  if (std::is_same<Tsampler<Tconfig, T, T>, mui::sampler_shepard_quintic<Tconfig, T, T>>::value)
+    return "shepard_quintic";
+  if (std::is_same<Tsampler<Tconfig, T, T>, mui::sampler_sph_quintic<Tconfig, T, T>>::value)
+    return "sph_quintic";
+  if (std::is_same<Tsampler<Tconfig, T, T>, mui::sampler_sum_quintic<Tconfig, T, T>>::value)
+    return "sum_quintic";
+  throw std::runtime_error("Invalid sampler type");
 }

--- a/wrappers/Python/mui4py/cpp/sampler_name.h
+++ b/wrappers/Python/mui4py/cpp/sampler_name.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
+* Copyright (C) 2023 C. Richardson, W. Liu                                   *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file sampler_name.h
- * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @author C. Richardson, W. Liu
  * @date 11 March 2023
  * @brief Spacial sampler names for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/temporal_name.h
+++ b/wrappers/Python/mui4py/cpp/temporal_name.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
+* Copyright (C) 2023 C. Richardson, W. Liu                                   *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file temporal_name.h
- * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @author C. Richardson, W. Liu
  * @date 11 March 2023
  * @brief Temporal sampler names for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/temporal_name.h
+++ b/wrappers/Python/mui4py/cpp/temporal_name.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -38,54 +38,22 @@
 *****************************************************************************/
 
 /**
- * @file mui4py.cpp
- * @author C. Richardson, E. R. Fernandez
- * @date 20 January 2023
- * @brief Main c++ file for MUI Python wrapper.
+ * @file temporal_name.h
+ * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @date 11 March 2023
+ * @brief Temporal sampler names for MUI Python wrapper.
  */
 
-#include <mui.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <mpi4py/mpi4py.h>
-#include <string>
-
-#include "config_name.h"
-#include "compiler_info.h"
-#include "sampler_name.h"
-#include "temporal_name.h"
-
-// Declaration of other files
-void temporal_sampler(py::module &m);
-void sampler(py::module &m);
-void geometry(py::module &m);
-void uniface(py::module &m);
-
-PYBIND11_MODULE(mui4py_mod, m)
+template <typename Tconfig, template <typename> class Ttemporal>
+std::string temporal_sampler_name()
 {
-  m.doc() = "MUI bindings for Python.";
-
-  // Expose numerical limits from C++
-  m.attr("numeric_limits_real") = std::numeric_limits<double>::min();
-  m.attr("numeric_limits_int") = std::numeric_limits<int>::min();
-
-  geometry(m);
-  sampler(m);
-  temporal_sampler(m);
-  uniface(m);
-
-  m.def("set_quiet", &mui::set_quiet, "");
-  m.def(
-      "mpi_split_by_app", []() -> py::handle
-      {
-    if (import_mpi4py() < 0)
-      Py_RETURN_NONE;
-    return PyMPIComm_New(mui::mpi_split_by_app()); },
-      "");
-  m.def("get_mpi_version", &get_mpi_version, "");
-  m.def("get_compiler_config", &get_compiler_config, "");
-  m.def("get_compiler_version", &get_compiler_version, "");
+  if (std::is_same<Ttemporal<Tconfig>, mui::temporal_sampler_exact<Tconfig>>::value)
+    return "temporal_exact";
+  if (std::is_same<Ttemporal<Tconfig>, mui::temporal_sampler_gauss<Tconfig>>::value)
+    return "temporal_gauss";
+  if (std::is_same<Ttemporal<Tconfig>, mui::temporal_sampler_sum<Tconfig>>::value)
+    return "temporal_sum";
+  if (std::is_same<Ttemporal<Tconfig>, mui::temporal_sampler_mean<Tconfig>>::value)
+    return "temporal_mean";
+  throw std::runtime_error("Invalid temporal sampler type");
 }

--- a/wrappers/Python/mui4py/cpp/temporal_sampler.cpp
+++ b/wrappers/Python/mui4py/cpp/temporal_sampler.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson                                           *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file temporal_sampler.cpp
- * @author C. Richardson
+ * @author C. Richardson, E. R. Fernandez
  * @date 20 January 2023
  * @brief Temporal samplers for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/temporal_sampler.cpp
+++ b/wrappers/Python/mui4py/cpp/temporal_sampler.cpp
@@ -1,5 +1,50 @@
+/*****************************************************************************
+* Multiscale Universal Interface Code Coupling Library                       *
+*                                                                            *
+* Copyright (C) 2023 C. Richardson                                           *
+*                                                                            *
+* This software is jointly licensed under the Apache License, Version 2.0    *
+* and the GNU General Public License version 3, you may use it according     *
+* to either.                                                                 *
+*                                                                            *
+* ** Apache License, version 2.0 **                                          *
+*                                                                            *
+* Licensed under the Apache License, Version 2.0 (the "License");            *
+* you may not use this file except in compliance with the License.           *
+* You may obtain a copy of the License at                                    *
+*                                                                            *
+* http://www.apache.org/licenses/LICENSE-2.0                                 *
+*                                                                            *
+* Unless required by applicable law or agreed to in writing, software        *
+* distributed under the License is distributed on an "AS IS" BASIS,          *
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+* See the License for the specific language governing permissions and        *
+* limitations under the License.                                             *
+*                                                                            *
+* ** GNU General Public License, version 3 **                                *
+*                                                                            *
+* This program is free software: you can redistribute it and/or modify       *
+* it under the terms of the GNU General Public License as published by       *
+* the Free Software Foundation, either version 3 of the License, or          *
+* (at your option) any later version.                                        *
+*                                                                            *
+* This program is distributed in the hope that it will be useful,            *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+* GNU General Public License for more details.                               *
+*                                                                            *
+* You should have received a copy of the GNU General Public License          *
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
+*****************************************************************************/
 
-#include "../../../../src/mui.h"
+/**
+ * @file temporal_sampler.cpp
+ * @author C. Richardson
+ * @date 20 January 2023
+ * @brief Temporal samplers for MUI Python wrapper.
+ */
+
+#include <mui.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>

--- a/wrappers/Python/mui4py/cpp/temporal_sampler.cpp
+++ b/wrappers/Python/mui4py/cpp/temporal_sampler.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson                                           *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file temporal_sampler.cpp
- * @author C. Richardson, E. R. Fernandez
+ * @author C. Richardson
  * @date 20 January 2023
  * @brief Temporal samplers for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/uniface.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface.cpp
@@ -45,13 +45,8 @@
  */
 
 #include <mui.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include <mpi4py/mpi4py.h>
-#include <string>
 
 #include "config_name.h"
 #include "sampler_name.h"
@@ -165,7 +160,7 @@ void declare_uniface_class(py::module &m)
 				if (import_mpi4py() < 0)
 				{
 					throw std::runtime_error(
-						"MUI Error [uniface.cpp]: mpi4py not loaded correctly\n");
+						"MUI Error [wrappers/Python/mui4py/cpp/uniface.cpp]: mpi4py not loaded correctly\n");
 				}
 			}
 
@@ -218,7 +213,6 @@ void declare_uniface_class(py::module &m)
            (void(Tclass::*)()) & Tclass::announce_send_disable, "")
       .def("announce_recv_disable",
            (void(Tclass::*)()) & Tclass::announce_recv_disable, "")
-      //    DEFINE_MUI_UNIFACE_FETCH_5ARGS() DEFINE_MUI_UNIFACE_FETCH_6ARGS()
 
       .def(py::init<const std::string &>());
 
@@ -237,27 +231,27 @@ void declare_uniface_class(py::module &m)
 
   declare_uniface_funcs<Tconfig, double>(uniface);
   declare_uniface_funcs<Tconfig, float>(uniface);
-  //declare_uniface_funcs<Tconfig, std::int32_t>(uniface);
-  //declare_uniface_funcs<Tconfig, std::int64_t>(uniface);
+  declare_uniface_funcs<Tconfig, std::int32_t>(uniface);
+  declare_uniface_funcs<Tconfig, std::int64_t>(uniface);
 }
 
 void uniface(py::module &m)
 {
 #ifdef PYTHON_INT_64
   declare_uniface_class<mui::mui_config_1dx>(m);
- // declare_uniface_class<mui::mui_config_2dx>(m);
+  declare_uniface_class<mui::mui_config_2dx>(m);
   declare_uniface_class<mui::mui_config_3dx>(m);
-//  declare_uniface_class<mui::mui_config_1fx>(m);
+  declare_uniface_class<mui::mui_config_1fx>(m);
   declare_uniface_class<mui::mui_config_2fx>(m);
- // declare_uniface_class<mui::mui_config_3fx>(m);
+  declare_uniface_class<mui::mui_config_3fx>(m);
 
 #elif defined PYTHON_INT_32
   declare_uniface_class<mui::mui_config_1d>(m);
-  //declare_uniface_class<mui::mui_config_2d>(m);
+  declare_uniface_class<mui::mui_config_2d>(m);
   declare_uniface_class<mui::mui_config_3d>(m);
-  //declare_uniface_class<mui::mui_config_1f>(m);
+  declare_uniface_class<mui::mui_config_1f>(m);
   declare_uniface_class<mui::mui_config_2f>(m);
-  //declare_uniface_class<mui::mui_config_3f>(m);
+  declare_uniface_class<mui::mui_config_3f>(m);
 
 #else
 #error PYTHON_INT_[32|64] not defined.

--- a/wrappers/Python/mui4py/cpp/uniface.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface.cpp
@@ -1,0 +1,265 @@
+/*****************************************************************************
+* Multiscale Universal Interface Code Coupling Library                       *
+*                                                                            *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
+*                                                                            *
+* This software is jointly licensed under the Apache License, Version 2.0    *
+* and the GNU General Public License version 3, you may use it according     *
+* to either.                                                                 *
+*                                                                            *
+* ** Apache License, version 2.0 **                                          *
+*                                                                            *
+* Licensed under the Apache License, Version 2.0 (the "License");            *
+* you may not use this file except in compliance with the License.           *
+* You may obtain a copy of the License at                                    *
+*                                                                            *
+* http://www.apache.org/licenses/LICENSE-2.0                                 *
+*                                                                            *
+* Unless required by applicable law or agreed to in writing, software        *
+* distributed under the License is distributed on an "AS IS" BASIS,          *
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+* See the License for the specific language governing permissions and        *
+* limitations under the License.                                             *
+*                                                                            *
+* ** GNU General Public License, version 3 **                                *
+*                                                                            *
+* This program is free software: you can redistribute it and/or modify       *
+* it under the terms of the GNU General Public License as published by       *
+* the Free Software Foundation, either version 3 of the License, or          *
+* (at your option) any later version.                                        *
+*                                                                            *
+* This program is distributed in the hope that it will be useful,            *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+* GNU General Public License for more details.                               *
+*                                                                            *
+* You should have received a copy of the GNU General Public License          *
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
+*****************************************************************************/
+
+/**
+ * @file uniface.cpp
+ * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @date 11 March 2023
+ * @brief Uniface calss for MUI Python wrapper.
+ */
+
+#include <mui.h>
+#include <pybind11/chrono.h>
+#include <pybind11/functional.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <mpi4py/mpi4py.h>
+#include <string>
+
+#include "config_name.h"
+#include "sampler_name.h"
+#include "temporal_name.h"
+
+template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler, template <typename> class Ttemporal>
+void declare_uniface_fetch(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Treal = typename Tconfig::REAL;
+  using Ttime = typename Tconfig::time_type;
+  using Titer = typename Tconfig::iterator_type;
+
+  std::string fetch_name = "fetch_" + type_name<T>() + "_" + sampler_name<Tconfig, T, Tsampler>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
+  uniface.def(fetch_name.c_str(),
+              (T(Tclass::*)(
+                  const std::string &, const mui::point<Treal, Tconfig::D> &, const Ttime,
+                  const Tsampler<Tconfig, T, T> &,
+                  const Ttemporal<Tconfig> &, bool)) &
+                  Tclass::fetch,
+              "")
+      .def(fetch_name.c_str(),
+           (T(Tclass::*)(
+               const std::string &, const mui::point<Treal, Tconfig::D> &, const Ttime,
+               const Titer,
+               const Tsampler<Tconfig, T, T> &,
+               const Ttemporal<Tconfig> &, bool)) &
+               Tclass::fetch,
+           "");
+}
+
+template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler, template <typename> class Ttemporal>
+void declare_uniface_fetch_many(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Treal = typename Tconfig::REAL;
+  using Ttime = typename Tconfig::time_type;
+
+  std::string fetch_many_name = "fetch_many_" + type_name<T>() + "_" + sampler_name<Tconfig, T, Tsampler>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
+  uniface.def(fetch_many_name.c_str(),
+              (py::array_t<T, py::array::c_style>(Tclass::*)(
+                  const std::string &attr,
+                  const py::array_t<Treal, py::array::c_style> points, const Ttime t,
+                  const Tsampler<Tconfig, T, T> &sampler,
+                  const Ttemporal<Tconfig> &t_sampler)) &
+                  Tclass::fetch_many,
+              "");
+}
+
+template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler>
+void declare_uniface_fetch_all_temporal(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_exact>(uniface);
+  declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
+  declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
+  declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
+
+  declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_exact>(uniface);
+  declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
+  declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
+  declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
+}
+
+template <typename Tconfig, typename T>
+void declare_uniface_funcs(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Treal = typename Tconfig::REAL;
+
+  std::string push_name = "push_" + type_name<T>();
+  std::string push_many_name = "push_many_" + type_name<T>();
+  std::string fetch_name = "fetch_" + type_name<T>();
+  uniface.def(push_name.c_str(),
+              (void(Tclass::*)(const std::string &, const mui::point<Treal, Tconfig::D> &,
+                               const T &)) &
+                  Tclass::push,
+              "")
+      .def(push_name.c_str(),
+           (void(Tclass::*)(const std::string &, const T &)) & Tclass::push,
+           "")
+      .def(fetch_name.c_str(),
+           (T(Tclass::*)(const std::string &)) & Tclass::fetch, "");
+
+  uniface.def(push_many_name.c_str(),
+              (void(Tclass::*)(const std::string &attr, const py::array_t<Treal> &points,
+                               const py::array_t<T> &values)) &
+                  Tclass::push_many,
+              "");
+  declare_uniface_fetch_all_temporal<Tconfig, T, mui::sampler_gauss>(uniface);
+  declare_uniface_fetch_all_temporal<Tconfig, T, mui::sampler_moving_average>(uniface);
+  declare_uniface_fetch_all_temporal<Tconfig, T, mui::sampler_nearest_neighbor>(uniface);
+  declare_uniface_fetch_all_temporal<Tconfig, T, mui::sampler_pseudo_n2_linear>(uniface);
+  declare_uniface_fetch_all_temporal<Tconfig, T, mui::sampler_pseudo_nearest_neighbor>(uniface);
+  declare_uniface_fetch_all_temporal<Tconfig, T, mui::sampler_shepard_quintic>(uniface);
+  declare_uniface_fetch_all_temporal<Tconfig, T, mui::sampler_sum_quintic>(uniface);
+  declare_uniface_fetch_all_temporal<Tconfig, T, mui::sampler_sph_quintic>(uniface);
+  declare_uniface_fetch_all_temporal<Tconfig, T, mui::sampler_exact>(uniface);
+  declare_uniface_fetch_all_temporal<Tconfig, T, mui::sampler_rbf>(uniface);
+}
+
+template <typename Tconfig>
+void declare_uniface_class(py::module &m)
+{
+  std::string name = "_create_uniface" + config_name<Tconfig>();
+
+  m.def(name.c_str(), [](std::string domain, std::vector<std::string> interfaces, pybind11::handle const& world)
+        {
+			// Import mpi4py if it does not exist.
+			if (!PyMPIComm_Get)
+			{
+				if (import_mpi4py() < 0)
+				{
+					throw std::runtime_error(
+						"MUI Error [uniface.cpp]: mpi4py not loaded correctly\n");
+				}
+			}
+
+			MPI_Comm comm;
+			MPI_Comm ric_mpiComm;
+
+			if (world.is_none()) {
+				comm = MPI_COMM_WORLD;
+				ric_mpiComm = reinterpret_cast<MPI_Comm>(comm);
+			} else {
+				PyObject *py_src = world.ptr();
+				MPI_Comm *comm_p = PyMPIComm_Get(py_src);
+				ric_mpiComm = reinterpret_cast<MPI_Comm>(*comm_p);
+			}
+            return mui::create_uniface<Tconfig>(domain, interfaces, ric_mpiComm);
+        });
+
+  m.def(name.c_str(), [](std::string domain, std::vector<std::string> interfaces)
+        {
+            return mui::create_uniface<Tconfig>(domain, interfaces, MPI_COMM_WORLD);
+        });
+
+  name = "_Uniface" + config_name<Tconfig>();
+  using Tclass = mui::uniface<Tconfig>;
+  using Treal = typename Tconfig::REAL;
+  using Ttime = typename Tconfig::time_type;
+  using Titer = typename Tconfig::iterator_type;
+  py::class_<Tclass> uniface(m, name.c_str());
+
+  uniface
+      .def("commit", (int(Tclass::*)(Ttime)) & Tclass::commit, "")
+      .def("forecast", (void(Tclass::*)(Ttime)) & Tclass::forecast, "")
+      //.def("is_ready", &Tclass::is_ready, "")
+      .def("barrier", (void(Tclass::*)(Ttime)) & Tclass::barrier, "")
+      .def("barrier", (void(Tclass::*)(Ttime, Titer)) & Tclass::barrier, "")
+      .def("forget", (void(Tclass::*)(Ttime, bool)) & Tclass::forget, "")
+      .def("forget", (void(Tclass::*)(Ttime, Ttime, bool)) & Tclass::forget, "")
+      .def("set_memory", (void(Tclass::*)(Ttime)) & Tclass::set_memory, "")
+      .def("announce_send_span",
+           (void(Tclass::*)(Ttime, Ttime, mui::geometry::any_shape<Tconfig>,
+                            bool synchronised)) &
+               Tclass::announce_send_span,
+           "")
+      .def("announce_recv_span",
+           (void(Tclass::*)(Ttime, Ttime, mui::geometry::any_shape<Tconfig>,
+                            bool synchronised)) &
+               Tclass::announce_recv_span,
+           "")
+      .def("announce_send_disable",
+           (void(Tclass::*)()) & Tclass::announce_send_disable, "")
+      .def("announce_recv_disable",
+           (void(Tclass::*)()) & Tclass::announce_recv_disable, "")
+      //    DEFINE_MUI_UNIFACE_FETCH_5ARGS() DEFINE_MUI_UNIFACE_FETCH_6ARGS()
+
+      .def(py::init<const std::string &>());
+
+  // Special cases for string
+  uniface.def("push_string",
+              (void(Tclass::*)(const std::string &, const mui::point<Treal, Tconfig::D> &,
+                               const std::string &)) &
+                  Tclass::push,
+              "")
+      .def("push_string",
+           (void(Tclass::*)(const std::string &, const std::string &)) & Tclass::push,
+           "")
+      .def("fetch_string",
+           (std::string(Tclass::*)(const std::string &)) & Tclass::fetch, "");
+  declare_uniface_fetch<Tconfig, std::string, mui::sampler_exact, mui::temporal_sampler_exact>(uniface);
+
+  declare_uniface_funcs<Tconfig, double>(uniface);
+  declare_uniface_funcs<Tconfig, float>(uniface);
+  //declare_uniface_funcs<Tconfig, std::int32_t>(uniface);
+  //declare_uniface_funcs<Tconfig, std::int64_t>(uniface);
+}
+
+void uniface(py::module &m)
+{
+#ifdef PYTHON_INT_64
+  declare_uniface_class<mui::mui_config_1dx>(m);
+ // declare_uniface_class<mui::mui_config_2dx>(m);
+  declare_uniface_class<mui::mui_config_3dx>(m);
+//  declare_uniface_class<mui::mui_config_1fx>(m);
+  declare_uniface_class<mui::mui_config_2fx>(m);
+ // declare_uniface_class<mui::mui_config_3fx>(m);
+
+#elif defined PYTHON_INT_32
+  declare_uniface_class<mui::mui_config_1d>(m);
+  //declare_uniface_class<mui::mui_config_2d>(m);
+  declare_uniface_class<mui::mui_config_3d>(m);
+  //declare_uniface_class<mui::mui_config_1f>(m);
+  declare_uniface_class<mui::mui_config_2f>(m);
+  //declare_uniface_class<mui::mui_config_3f>(m);
+
+#else
+#error PYTHON_INT_[32|64] not defined.
+#endif
+}

--- a/wrappers/Python/mui4py/cpp/uniface1d.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface1d.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -38,61 +38,23 @@
 *****************************************************************************/
 
 /**
- * @file mui4py.cpp
- * @author C. Richardson, E. R. Fernandez
- * @date 20 January 2023
- * @brief Main c++ file for MUI Python wrapper.
+ * @file uniface1d.cpp
+ * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @date 11 March 2023
+ * @brief Uniface 1-D double for MUI Python wrapper.
  */
 
-#include <mui.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <mpi4py/mpi4py.h>
-#include <string>
+#include "uniface_base.h"
 
-#include "compiler_info.h"
-
-// Declaration of other files
-void temporal_sampler(py::module &m);
-void sampler(py::module &m);
-void geometry(py::module &m);
-void uniface1d(py::module &m);
-void uniface2d(py::module &m);
-void uniface3d(py::module &m);
-void uniface1f(py::module &m);
-void uniface2f(py::module &m);
-void uniface3f(py::module &m);
-
-PYBIND11_MODULE(mui4py_mod, m)
+void uniface1d(py::module &m)
 {
-  m.doc() = "MUI bindings for Python.";
+#ifdef PYTHON_INT_64
+  declare_uniface_class<mui::mui_config_1dx>(m);
 
-  // Expose numerical limits from C++
-  m.attr("numeric_limits_real") = std::numeric_limits<double>::min();
-  m.attr("numeric_limits_int") = std::numeric_limits<int>::min();
+#elif defined PYTHON_INT_32
+  declare_uniface_class<mui::mui_config_1d>(m);
 
-  geometry(m);
-  sampler(m);
-  temporal_sampler(m);
-  uniface1d(m);
-  uniface2d(m);
-  uniface3d(m);
-  uniface1f(m);
-  uniface2f(m);
-  uniface3f(m);
-
-  m.def("set_quiet", &mui::set_quiet, "");
-  m.def(
-      "mpi_split_by_app", []() -> py::handle
-      {
-    if (import_mpi4py() < 0)
-      Py_RETURN_NONE;
-    return PyMPIComm_New(mui::mpi_split_by_app()); },
-      "");
-  m.def("get_mpi_version", &get_mpi_version, "");
-  m.def("get_compiler_config", &get_compiler_config, "");
-  m.def("get_compiler_version", &get_compiler_version, "");
+#else
+#error PYTHON_INT_[32|64] not defined.
+#endif
 }

--- a/wrappers/Python/mui4py/cpp/uniface1d.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface1d.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
+* Copyright (C) 2023 C. Richardson, W. Liu                                   *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file uniface1d.cpp
- * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @author C. Richardson, W. Liu
  * @date 11 March 2023
  * @brief Uniface 1-D double for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/uniface1f.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface1f.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -38,61 +38,24 @@
 *****************************************************************************/
 
 /**
- * @file mui4py.cpp
- * @author C. Richardson, E. R. Fernandez
- * @date 20 January 2023
- * @brief Main c++ file for MUI Python wrapper.
+ * @file uniface1d.cpp
+ * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @date 11 March 2023
+ * @brief Uniface 1-D float for MUI Python wrapper.
  */
 
-#include <mui.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <mpi4py/mpi4py.h>
-#include <string>
+#include "uniface_base.h"
 
-#include "compiler_info.h"
-
-// Declaration of other files
-void temporal_sampler(py::module &m);
-void sampler(py::module &m);
-void geometry(py::module &m);
-void uniface1d(py::module &m);
-void uniface2d(py::module &m);
-void uniface3d(py::module &m);
-void uniface1f(py::module &m);
-void uniface2f(py::module &m);
-void uniface3f(py::module &m);
-
-PYBIND11_MODULE(mui4py_mod, m)
+void uniface1f(py::module &m)
 {
-  m.doc() = "MUI bindings for Python.";
+#ifdef PYTHON_INT_64
+  declare_uniface_class<mui::mui_config_1fx>(m);
 
-  // Expose numerical limits from C++
-  m.attr("numeric_limits_real") = std::numeric_limits<double>::min();
-  m.attr("numeric_limits_int") = std::numeric_limits<int>::min();
+#elif defined PYTHON_INT_32
+  declare_uniface_class<mui::mui_config_1f>(m);
 
-  geometry(m);
-  sampler(m);
-  temporal_sampler(m);
-  uniface1d(m);
-  uniface2d(m);
-  uniface3d(m);
-  uniface1f(m);
-  uniface2f(m);
-  uniface3f(m);
 
-  m.def("set_quiet", &mui::set_quiet, "");
-  m.def(
-      "mpi_split_by_app", []() -> py::handle
-      {
-    if (import_mpi4py() < 0)
-      Py_RETURN_NONE;
-    return PyMPIComm_New(mui::mpi_split_by_app()); },
-      "");
-  m.def("get_mpi_version", &get_mpi_version, "");
-  m.def("get_compiler_config", &get_compiler_config, "");
-  m.def("get_compiler_version", &get_compiler_version, "");
+#else
+#error PYTHON_INT_[32|64] not defined.
+#endif
 }

--- a/wrappers/Python/mui4py/cpp/uniface1f.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface1f.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
+* Copyright (C) 2023 C. Richardson, W. Liu                                   *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file uniface1d.cpp
- * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @author C. Richardson, W. Liu
  * @date 11 March 2023
  * @brief Uniface 1-D float for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/uniface2d.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface2d.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -38,61 +38,25 @@
 *****************************************************************************/
 
 /**
- * @file mui4py.cpp
- * @author C. Richardson, E. R. Fernandez
- * @date 20 January 2023
- * @brief Main c++ file for MUI Python wrapper.
+ * @file uniface1d.cpp
+ * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @date 11 March 2023
+ * @brief Uniface 2-D double for MUI Python wrapper.
  */
 
-#include <mui.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <mpi4py/mpi4py.h>
-#include <string>
+#include "uniface_base.h"
 
-#include "compiler_info.h"
-
-// Declaration of other files
-void temporal_sampler(py::module &m);
-void sampler(py::module &m);
-void geometry(py::module &m);
-void uniface1d(py::module &m);
-void uniface2d(py::module &m);
-void uniface3d(py::module &m);
-void uniface1f(py::module &m);
-void uniface2f(py::module &m);
-void uniface3f(py::module &m);
-
-PYBIND11_MODULE(mui4py_mod, m)
+void uniface2d(py::module &m)
 {
-  m.doc() = "MUI bindings for Python.";
+#ifdef PYTHON_INT_64
 
-  // Expose numerical limits from C++
-  m.attr("numeric_limits_real") = std::numeric_limits<double>::min();
-  m.attr("numeric_limits_int") = std::numeric_limits<int>::min();
+  declare_uniface_class<mui::mui_config_2dx>(m);
 
-  geometry(m);
-  sampler(m);
-  temporal_sampler(m);
-  uniface1d(m);
-  uniface2d(m);
-  uniface3d(m);
-  uniface1f(m);
-  uniface2f(m);
-  uniface3f(m);
+#elif defined PYTHON_INT_32
 
-  m.def("set_quiet", &mui::set_quiet, "");
-  m.def(
-      "mpi_split_by_app", []() -> py::handle
-      {
-    if (import_mpi4py() < 0)
-      Py_RETURN_NONE;
-    return PyMPIComm_New(mui::mpi_split_by_app()); },
-      "");
-  m.def("get_mpi_version", &get_mpi_version, "");
-  m.def("get_compiler_config", &get_compiler_config, "");
-  m.def("get_compiler_version", &get_compiler_version, "");
+  declare_uniface_class<mui::mui_config_2d>(m);
+
+#else
+#error PYTHON_INT_[32|64] not defined.
+#endif
 }

--- a/wrappers/Python/mui4py/cpp/uniface2d.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface2d.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
+* Copyright (C) 2023 C. Richardson, W. Liu                                   *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file uniface1d.cpp
- * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @author C. Richardson, W. Liu
  * @date 11 March 2023
  * @brief Uniface 2-D double for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/uniface2f.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface2f.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
+* Copyright (C) 2023 C. Richardson, W. Liu                                   *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file uniface1d.cpp
- * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @author C. Richardson, W. Liu
  * @date 11 March 2023
  * @brief Uniface 2-D float for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/uniface2f.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface2f.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -38,61 +38,25 @@
 *****************************************************************************/
 
 /**
- * @file mui4py.cpp
- * @author C. Richardson, E. R. Fernandez
- * @date 20 January 2023
- * @brief Main c++ file for MUI Python wrapper.
+ * @file uniface1d.cpp
+ * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @date 11 March 2023
+ * @brief Uniface 2-D float for MUI Python wrapper.
  */
 
-#include <mui.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <mpi4py/mpi4py.h>
-#include <string>
+#include "uniface_base.h"
 
-#include "compiler_info.h"
-
-// Declaration of other files
-void temporal_sampler(py::module &m);
-void sampler(py::module &m);
-void geometry(py::module &m);
-void uniface1d(py::module &m);
-void uniface2d(py::module &m);
-void uniface3d(py::module &m);
-void uniface1f(py::module &m);
-void uniface2f(py::module &m);
-void uniface3f(py::module &m);
-
-PYBIND11_MODULE(mui4py_mod, m)
+void uniface2f(py::module &m)
 {
-  m.doc() = "MUI bindings for Python.";
+#ifdef PYTHON_INT_64
 
-  // Expose numerical limits from C++
-  m.attr("numeric_limits_real") = std::numeric_limits<double>::min();
-  m.attr("numeric_limits_int") = std::numeric_limits<int>::min();
+  declare_uniface_class<mui::mui_config_2fx>(m);
 
-  geometry(m);
-  sampler(m);
-  temporal_sampler(m);
-  uniface1d(m);
-  uniface2d(m);
-  uniface3d(m);
-  uniface1f(m);
-  uniface2f(m);
-  uniface3f(m);
+#elif defined PYTHON_INT_32
 
-  m.def("set_quiet", &mui::set_quiet, "");
-  m.def(
-      "mpi_split_by_app", []() -> py::handle
-      {
-    if (import_mpi4py() < 0)
-      Py_RETURN_NONE;
-    return PyMPIComm_New(mui::mpi_split_by_app()); },
-      "");
-  m.def("get_mpi_version", &get_mpi_version, "");
-  m.def("get_compiler_config", &get_compiler_config, "");
-  m.def("get_compiler_version", &get_compiler_version, "");
+  declare_uniface_class<mui::mui_config_2f>(m);
+
+#else
+#error PYTHON_INT_[32|64] not defined.
+#endif
 }

--- a/wrappers/Python/mui4py/cpp/uniface3d.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface3d.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -38,61 +38,24 @@
 *****************************************************************************/
 
 /**
- * @file mui4py.cpp
- * @author C. Richardson, E. R. Fernandez
- * @date 20 January 2023
- * @brief Main c++ file for MUI Python wrapper.
+ * @file uniface1d.cpp
+ * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @date 11 March 2023
+ * @brief Uniface 3-D double for MUI Python wrapper.
  */
 
-#include <mui.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <mpi4py/mpi4py.h>
-#include <string>
+#include "uniface_base.h"
 
-#include "compiler_info.h"
-
-// Declaration of other files
-void temporal_sampler(py::module &m);
-void sampler(py::module &m);
-void geometry(py::module &m);
-void uniface1d(py::module &m);
-void uniface2d(py::module &m);
-void uniface3d(py::module &m);
-void uniface1f(py::module &m);
-void uniface2f(py::module &m);
-void uniface3f(py::module &m);
-
-PYBIND11_MODULE(mui4py_mod, m)
+void uniface3d(py::module &m)
 {
-  m.doc() = "MUI bindings for Python.";
+#ifdef PYTHON_INT_64
+  declare_uniface_class<mui::mui_config_3dx>(m);
 
-  // Expose numerical limits from C++
-  m.attr("numeric_limits_real") = std::numeric_limits<double>::min();
-  m.attr("numeric_limits_int") = std::numeric_limits<int>::min();
+#elif defined PYTHON_INT_32
 
-  geometry(m);
-  sampler(m);
-  temporal_sampler(m);
-  uniface1d(m);
-  uniface2d(m);
-  uniface3d(m);
-  uniface1f(m);
-  uniface2f(m);
-  uniface3f(m);
+  declare_uniface_class<mui::mui_config_3d>(m);
 
-  m.def("set_quiet", &mui::set_quiet, "");
-  m.def(
-      "mpi_split_by_app", []() -> py::handle
-      {
-    if (import_mpi4py() < 0)
-      Py_RETURN_NONE;
-    return PyMPIComm_New(mui::mpi_split_by_app()); },
-      "");
-  m.def("get_mpi_version", &get_mpi_version, "");
-  m.def("get_compiler_config", &get_compiler_config, "");
-  m.def("get_compiler_version", &get_compiler_version, "");
+#else
+#error PYTHON_INT_[32|64] not defined.
+#endif
 }

--- a/wrappers/Python/mui4py/cpp/uniface3d.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface3d.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
+* Copyright (C) 2023 C. Richardson, W. Liu                                   *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file uniface1d.cpp
- * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @author C. Richardson, W. Liu
  * @date 11 March 2023
  * @brief Uniface 3-D double for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/uniface3f.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface3f.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
+* Copyright (C) 2023 C. Richardson, W. Liu                                   *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -39,7 +39,7 @@
 
 /**
  * @file uniface1d.cpp
- * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @author C. Richardson, W. Liu
  * @date 11 March 2023
  * @brief Uniface 3-D float for MUI Python wrapper.
  */

--- a/wrappers/Python/mui4py/cpp/uniface3f.cpp
+++ b/wrappers/Python/mui4py/cpp/uniface3f.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson, E. R. Fernandez                          *
+* Copyright (C) 2023 C. Richardson, E. R. Fernandez, W. Liu                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -38,61 +38,25 @@
 *****************************************************************************/
 
 /**
- * @file mui4py.cpp
- * @author C. Richardson, E. R. Fernandez
- * @date 20 January 2023
- * @brief Main c++ file for MUI Python wrapper.
+ * @file uniface1d.cpp
+ * @author C. Richardson, E. R. Fernandez, W. Liu
+ * @date 11 March 2023
+ * @brief Uniface 3-D float for MUI Python wrapper.
  */
 
-#include <mui.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <mpi4py/mpi4py.h>
-#include <string>
+#include "uniface_base.h"
 
-#include "compiler_info.h"
-
-// Declaration of other files
-void temporal_sampler(py::module &m);
-void sampler(py::module &m);
-void geometry(py::module &m);
-void uniface1d(py::module &m);
-void uniface2d(py::module &m);
-void uniface3d(py::module &m);
-void uniface1f(py::module &m);
-void uniface2f(py::module &m);
-void uniface3f(py::module &m);
-
-PYBIND11_MODULE(mui4py_mod, m)
+void uniface3f(py::module &m)
 {
-  m.doc() = "MUI bindings for Python.";
+#ifdef PYTHON_INT_64
 
-  // Expose numerical limits from C++
-  m.attr("numeric_limits_real") = std::numeric_limits<double>::min();
-  m.attr("numeric_limits_int") = std::numeric_limits<int>::min();
+  declare_uniface_class<mui::mui_config_3fx>(m);
 
-  geometry(m);
-  sampler(m);
-  temporal_sampler(m);
-  uniface1d(m);
-  uniface2d(m);
-  uniface3d(m);
-  uniface1f(m);
-  uniface2f(m);
-  uniface3f(m);
+#elif defined PYTHON_INT_32
 
-  m.def("set_quiet", &mui::set_quiet, "");
-  m.def(
-      "mpi_split_by_app", []() -> py::handle
-      {
-    if (import_mpi4py() < 0)
-      Py_RETURN_NONE;
-    return PyMPIComm_New(mui::mpi_split_by_app()); },
-      "");
-  m.def("get_mpi_version", &get_mpi_version, "");
-  m.def("get_compiler_config", &get_compiler_config, "");
-  m.def("get_compiler_version", &get_compiler_version, "");
+  declare_uniface_class<mui::mui_config_3f>(m);
+
+#else
+#error PYTHON_INT_[32|64] not defined.
+#endif
 }

--- a/wrappers/Python/mui4py/cpp/uniface_base.h
+++ b/wrappers/Python/mui4py/cpp/uniface_base.h
@@ -52,25 +52,48 @@
 #include "sampler_name.h"
 #include "temporal_name.h"
 
+template <typename Tconfig, typename T>
+void declare_uniface_fetch_single(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+
+  std::string fetch_name = "fetch_single_" + type_name<T>();
+  uniface.def(fetch_name.c_str(), (T(Tclass::*)(const std::string &)) & Tclass::fetch, "");
+}
+
 template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler, template <typename> class Ttemporal>
 void declare_uniface_fetch(py::class_<mui::uniface<Tconfig>> &uniface)
 {
   using Tclass = mui::uniface<Tconfig>;
   using Treal = typename Tconfig::REAL;
   using Ttime = typename Tconfig::time_type;
-  using Titer = typename Tconfig::iterator_type;
 
   std::string fetch_name = "fetch_" + type_name<T>() + "_" + sampler_name<Tconfig, T, Tsampler>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
   uniface.def(fetch_name.c_str(),
               (T(Tclass::*)(
-                  const std::string &, const mui::point<Treal, Tconfig::D> &, const Ttime,
+                  const std::string &,
+				  const mui::point<Treal, Tconfig::D> &,
+				  const Ttime,
                   const Tsampler<Tconfig, T, T> &,
                   const Ttemporal<Tconfig> &, bool)) &
                   Tclass::fetch,
-              "")
-      .def(fetch_name.c_str(),
+              "");
+}
+
+template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler, template <typename> class Ttemporal>
+void declare_uniface_fetch_dual(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Treal = typename Tconfig::REAL;
+  using Ttime = typename Tconfig::time_type;
+  using Titer = typename Tconfig::iterator_type;
+
+  std::string fetch_name = "fetch_dual_" + type_name<T>() + "_" + sampler_name<Tconfig, T, Tsampler>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
+  uniface.def(fetch_name.c_str(),
            (T(Tclass::*)(
-               const std::string &, const mui::point<Treal, Tconfig::D> &, const Ttime,
+               const std::string &,
+			   const mui::point<Treal, Tconfig::D> &,
+			   const Ttime,
                const Titer,
                const Tsampler<Tconfig, T, T> &,
                const Ttemporal<Tconfig> &, bool)) &
@@ -88,26 +111,154 @@ void declare_uniface_fetch_many(py::class_<mui::uniface<Tconfig>> &uniface)
   std::string fetch_many_name = "fetch_many_" + type_name<T>() + "_" + sampler_name<Tconfig, T, Tsampler>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
   uniface.def(fetch_many_name.c_str(),
               (py::array_t<T, py::array::c_style>(Tclass::*)(
-                  const std::string &attr,
-                  const py::array_t<Treal, py::array::c_style> points, const Ttime t,
-                  const Tsampler<Tconfig, T, T> &sampler,
-                  const Ttemporal<Tconfig> &t_sampler)) &
+                  const std::string &,
+                  const py::array_t<Treal, py::array::c_style>,
+				  const Ttime,
+                  const Tsampler<Tconfig, T, T> &,
+                  const Ttemporal<Tconfig> &)) &
                   Tclass::fetch_many,
+              "");
+}
+
+template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler, template <typename> class Ttemporal>
+void declare_uniface_fetch_many_dual(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Treal = typename Tconfig::REAL;
+  using Ttime = typename Tconfig::time_type;
+  using Titer = typename Tconfig::iterator_type;
+
+  std::string fetch_many_name = "fetch_many_dual_" + type_name<T>() + "_" + sampler_name<Tconfig, T, Tsampler>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
+  uniface.def(fetch_many_name.c_str(),
+              (py::array_t<T, py::array::c_style>(Tclass::*)(
+                  const std::string &,
+                  const py::array_t<Treal, py::array::c_style>,
+				  const Ttime,
+				  const Titer,
+                  const Tsampler<Tconfig, T, T> &,
+                  const Ttemporal<Tconfig> &)) &
+                  Tclass::fetch_many,
+              "");
+}
+
+template <typename Tconfig, typename T, template <typename> class Ttemporal>
+void declare_uniface_fetch_points(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Ttime = typename Tconfig::time_type;
+  using Treal = typename Tconfig::REAL;
+
+  std::string fetch_name = "fetch_points_" + type_name<T>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
+  uniface.def(fetch_name.c_str(),
+              (py::array_t<Treal, py::array::c_style>(Tclass::*)(
+                  const std::string &,
+				  const Ttime,
+                  const Ttemporal<Tconfig> &, bool)) &
+                  Tclass::fetch_points_np,
+              "");
+}
+
+template <typename Tconfig, typename T, template <typename> class Ttemporal>
+void declare_uniface_fetch_points_dual(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Ttime = typename Tconfig::time_type;
+  using Titer = typename Tconfig::iterator_type;
+  using Treal = typename Tconfig::REAL;
+
+  std::string fetch_name = "fetch_points_dual_" + type_name<T>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
+  uniface.def(fetch_name.c_str(),
+              (py::array_t<Treal, py::array::c_style>(Tclass::*)(
+                  const std::string &,
+				  const Ttime,
+				  const Titer,
+                  const Ttemporal<Tconfig> &, bool)) &
+                  Tclass::fetch_points_np,
+              "");
+}
+
+template <typename Tconfig, typename T, template <typename> class Ttemporal>
+void declare_uniface_fetch_values(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Ttime = typename Tconfig::time_type;
+
+  std::string fetch_name = "fetch_values_" + type_name<T>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
+  uniface.def(fetch_name.c_str(),
+              (py::array_t<T, py::array::c_style>(Tclass::*)(
+                  const std::string &,
+				  const Ttime,
+                  const Ttemporal<Tconfig> &, bool)) &
+                  Tclass::fetch_values,
+              "");
+}
+
+template <typename Tconfig, typename T, template <typename> class Ttemporal>
+void declare_uniface_fetch_values_dual(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Ttime = typename Tconfig::time_type;
+  using Titer = typename Tconfig::iterator_type;
+
+  std::string fetch_name = "fetch_values_dual_" + type_name<T>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
+  uniface.def(fetch_name.c_str(),
+              (py::array_t<T, py::array::c_style>(Tclass::*)(
+                  const std::string &,
+				  const Ttime,
+				  const Titer,
+                  const Ttemporal<Tconfig> &, bool)) &
+                  Tclass::fetch_values,
               "");
 }
 
 template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler>
 void declare_uniface_fetch_all_temporal(py::class_<mui::uniface<Tconfig>> &uniface)
 {
+
   declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_exact>(uniface);
   declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
 
+  declare_uniface_fetch_dual<Tconfig, T, Tsampler, mui::temporal_sampler_exact>(uniface);
+  declare_uniface_fetch_dual<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
+  declare_uniface_fetch_dual<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
+  declare_uniface_fetch_dual<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
+
   declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_exact>(uniface);
   declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
+
+  declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_exact>(uniface);
+  declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
+  declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
+  declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
+}
+
+template <typename Tconfig, typename T>
+void declare_uniface_fetch_points_values_temporal(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+
+  declare_uniface_fetch_points<Tconfig, T, mui::temporal_sampler_exact>(uniface);
+  declare_uniface_fetch_points<Tconfig, T, mui::temporal_sampler_gauss>(uniface);
+  declare_uniface_fetch_points<Tconfig, T, mui::temporal_sampler_mean>(uniface);
+  declare_uniface_fetch_points<Tconfig, T, mui::temporal_sampler_sum>(uniface);
+
+  declare_uniface_fetch_points_dual<Tconfig, T, mui::temporal_sampler_exact>(uniface);
+  declare_uniface_fetch_points_dual<Tconfig, T, mui::temporal_sampler_gauss>(uniface);
+  declare_uniface_fetch_points_dual<Tconfig, T, mui::temporal_sampler_mean>(uniface);
+  declare_uniface_fetch_points_dual<Tconfig, T, mui::temporal_sampler_sum>(uniface);
+
+  declare_uniface_fetch_values<Tconfig, T, mui::temporal_sampler_exact>(uniface);
+  declare_uniface_fetch_values<Tconfig, T, mui::temporal_sampler_gauss>(uniface);
+  declare_uniface_fetch_values<Tconfig, T, mui::temporal_sampler_mean>(uniface);
+  declare_uniface_fetch_values<Tconfig, T, mui::temporal_sampler_sum>(uniface);
+
+  declare_uniface_fetch_values_dual<Tconfig, T, mui::temporal_sampler_exact>(uniface);
+  declare_uniface_fetch_values_dual<Tconfig, T, mui::temporal_sampler_gauss>(uniface);
+  declare_uniface_fetch_values_dual<Tconfig, T, mui::temporal_sampler_mean>(uniface);
+  declare_uniface_fetch_values_dual<Tconfig, T, mui::temporal_sampler_sum>(uniface);
 }
 
 template <typename Tconfig, typename T>
@@ -244,8 +395,19 @@ void declare_uniface_class (py::module &m)
       .def(py::init<const std::string &>());
 
   declare_uniface_string<Tconfig> (uniface);
+
   declare_uniface_funcs<Tconfig, double>(uniface);
   declare_uniface_funcs<Tconfig, float>(uniface);
   declare_uniface_funcs<Tconfig, std::int32_t>(uniface);
   declare_uniface_funcs<Tconfig, std::int64_t>(uniface);
+
+  declare_uniface_fetch_single<Tconfig, double>(uniface);
+  declare_uniface_fetch_single<Tconfig, float>(uniface);
+  declare_uniface_fetch_single<Tconfig, std::int32_t>(uniface);
+  declare_uniface_fetch_single<Tconfig, std::int64_t>(uniface);
+
+  declare_uniface_fetch_points_values_temporal<Tconfig, double>(uniface);
+  declare_uniface_fetch_points_values_temporal<Tconfig, float>(uniface);
+  declare_uniface_fetch_points_values_temporal<Tconfig, std::int32_t>(uniface);
+  declare_uniface_fetch_points_values_temporal<Tconfig, std::int64_t>(uniface);
 }

--- a/wrappers/Python/mui4py/cpp/uniface_base.h
+++ b/wrappers/Python/mui4py/cpp/uniface_base.h
@@ -211,29 +211,36 @@ void declare_uniface_class (py::module &m)
   py::class_<Tclass> uniface(m, name.c_str());
 
   uniface
-      .def("commit", (int(Tclass::*)(Ttime)) & Tclass::commit, "")
-      .def("forecast", (void(Tclass::*)(Ttime)) & Tclass::forecast, "")
-      //.def("is_ready", &Tclass::is_ready, "")
+      .def("commit", (int(Tclass::*)(Ttime, Titer)) & Tclass::commit, "")
+      .def("forecast", (void(Tclass::*)(Ttime, Titer)) & Tclass::forecast, "")
+      .def("is_ready", (bool(Tclass::*)(const std::string &, Ttime) const) &Tclass::is_ready, "")
+      .def("is_ready", (bool(Tclass::*)(const std::string &, Ttime, Titer) const) &Tclass::is_ready, "")
       .def("barrier", (void(Tclass::*)(Ttime)) & Tclass::barrier, "")
       .def("barrier", (void(Tclass::*)(Ttime, Titer)) & Tclass::barrier, "")
       .def("forget", (void(Tclass::*)(Ttime, bool)) & Tclass::forget, "")
+      .def("forget", (void(Tclass::*)(std::pair<Ttime,Titer>, bool)) & Tclass::forget, "")
       .def("forget", (void(Tclass::*)(Ttime, Ttime, bool)) & Tclass::forget, "")
+      .def("forget", (void(Tclass::*)(std::pair<Ttime,Titer>, std::pair<Ttime,Titer>, bool)) & Tclass::forget, "")
       .def("set_memory", (void(Tclass::*)(Ttime)) & Tclass::set_memory, "")
+      .def("uri_host", (std::string(Tclass::*)()) & Tclass::uri_host, "")
+      .def("uri_path", (std::string(Tclass::*)()) & Tclass::uri_path, "")
+      .def("uri_protocol", (std::string(Tclass::*)()) & Tclass::uri_protocol, "")
       .def("announce_send_span",
            (void(Tclass::*)(Ttime, Ttime, mui::geometry::any_shape<Tconfig>,
-                            bool synchronised)) &
-               Tclass::announce_send_span,
-           "")
+                            bool)) & Tclass::announce_send_span, "")
       .def("announce_recv_span",
            (void(Tclass::*)(Ttime, Ttime, mui::geometry::any_shape<Tconfig>,
-                            bool synchronised)) &
-               Tclass::announce_recv_span,
-           "")
+                            bool)) & Tclass::announce_recv_span, "")
       .def("announce_send_disable",
-           (void(Tclass::*)()) & Tclass::announce_send_disable, "")
+           (void(Tclass::*)(bool)) & Tclass::announce_send_disable, "")
       .def("announce_recv_disable",
-           (void(Tclass::*)()) & Tclass::announce_recv_disable, "")
-
+           (void(Tclass::*)(bool)) & Tclass::announce_recv_disable, "")
+      .def("update_smart_send",
+           (void(Tclass::*)(Ttime)) & Tclass::update_smart_send, "")
+      .def("barrier_ss_send",
+           (void(Tclass::*)()) & Tclass::barrier_ss_send, "")
+      .def("barrier_ss_recv",
+           (void(Tclass::*)()) & Tclass::barrier_ss_recv, "")
       .def(py::init<const std::string &>());
 
   declare_uniface_string<Tconfig> (uniface);

--- a/wrappers/Python/mui4py/geometry.py
+++ b/wrappers/Python/mui4py/geometry.py
@@ -1,3 +1,4 @@
+"""
 ##############################################################################
 # Multiscale Universal Interface Code Coupling Library                       #
 #                                                                            #
@@ -42,6 +43,7 @@
 # @date 25 January 2019
 # @brief Geometry functions for MUI Python wrapper.
 #
+"""
 
 from mui4py.common import CppClass, _Point
 from mui4py.config import Config

--- a/wrappers/Python/mui4py/geometry.py
+++ b/wrappers/Python/mui4py/geometry.py
@@ -1,3 +1,48 @@
+##############################################################################
+# Multiscale Universal Interface Code Coupling Library                       #
+#                                                                            #
+# Copyright (C) 2023 E. R. Fernandez                                         #
+#                                                                            #
+# This software is jointly licensed under the Apache License, Version 2.0    #
+# and the GNU General Public License version 3, you may use it according     #
+# to either.                                                                 #
+#                                                                            #
+# ** Apache License, version 2.0 **                                          #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License");            #
+# you may not use this file except in compliance with the License.           #
+# You may obtain a copy of the License at                                    #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#                                                                            #
+# ** GNU General Public License, version 3 **                                #
+#                                                                            #
+# This program is free software: you can redistribute it and/or modify       #
+# it under the terms of the GNU General Public License as published by       #
+# the Free Software Foundation, either version 3 of the License, or          #
+# (at your option) any later version.                                        #
+#                                                                            #
+# This program is distributed in the hope that it will be useful,            #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              #
+# GNU General Public License for more details.                               #
+#                                                                            #
+# You should have received a copy of the GNU General Public License          #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.      #
+##############################################################################
+#
+# @file geometry.py
+# @author E. R. Fernandez
+# @date 25 January 2019
+# @brief Geometry functions for MUI Python wrapper.
+#
+
 from mui4py.common import CppClass, _Point
 from mui4py.config import Config
 

--- a/wrappers/Python/mui4py/mui4py.py
+++ b/wrappers/Python/mui4py/mui4py.py
@@ -1,3 +1,4 @@
+"""
 ##############################################################################
 # Multiscale Universal Interface Code Coupling Library                       #
 #                                                                            #
@@ -42,6 +43,7 @@
 # @date 25 January 2019
 # @brief main file for the MUI Python wrapper.
 #
+"""
 
 import mui4py.mui4py_mod as mui4py_mod
 from mui4py.common import CppClass, get_cpp_name, array2Point

--- a/wrappers/Python/mui4py/mui4py.py
+++ b/wrappers/Python/mui4py/mui4py.py
@@ -1,3 +1,48 @@
+##############################################################################
+# Multiscale Universal Interface Code Coupling Library                       #
+#                                                                            #
+# Copyright (C) 2023 E. R. Fernandez                                         #
+#                                                                            #
+# This software is jointly licensed under the Apache License, Version 2.0    #
+# and the GNU General Public License version 3, you may use it according     #
+# to either.                                                                 #
+#                                                                            #
+# ** Apache License, version 2.0 **                                          #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License");            #
+# you may not use this file except in compliance with the License.           #
+# You may obtain a copy of the License at                                    #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#                                                                            #
+# ** GNU General Public License, version 3 **                                #
+#                                                                            #
+# This program is free software: you can redistribute it and/or modify       #
+# it under the terms of the GNU General Public License as published by       #
+# the Free Software Foundation, either version 3 of the License, or          #
+# (at your option) any later version.                                        #
+#                                                                            #
+# This program is distributed in the hope that it will be useful,            #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              #
+# GNU General Public License for more details.                               #
+#                                                                            #
+# You should have received a copy of the GNU General Public License          #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.      #
+##############################################################################
+#
+# @file mui4py.py
+# @author E. R. Fernandez
+# @date 25 January 2019
+# @brief main file for the MUI Python wrapper.
+#
+
 import mui4py.mui4py_mod as mui4py_mod
 from mui4py.common import CppClass, get_cpp_name, array2Point
 from mui4py.config import Config

--- a/wrappers/Python/mui4py/mui4py.py
+++ b/wrappers/Python/mui4py/mui4py.py
@@ -7,15 +7,17 @@ from mui4py.samplers import Sampler, TemporalSampler
 import copy
 
 
-# TODO: Add communicator parameter
-def create_unifaces(domain, ifaces_names, config):
+def create_unifaces(domain, ifaces_names, config, world=None):
     assert type(ifaces_names) == list
     assert type(domain) == str
     assert issubclass(config.__class__, Config)
     ifaces_out = {}
     cpp_obj_name = get_cpp_name("create_uniface", config.dim,
                                 config.float_type, config.int_type)
-    ifaceraw = getattr(mui4py_mod, cpp_obj_name)(domain, ifaces_names)
+    if world is not None:
+        ifaceraw = getattr(mui4py_mod, cpp_obj_name)(domain, ifaces_names, world)
+    else:
+        ifaceraw = getattr(mui4py_mod, cpp_obj_name)(domain, ifaces_names)
     for i, obj in enumerate(ifaceraw):
         ifaces_out[ifaces_names[i]] = Uniface(config=config, cpp_obj=obj)
     return ifaces_out

--- a/wrappers/Python/mui4py/mui4py.py
+++ b/wrappers/Python/mui4py/mui4py.py
@@ -287,7 +287,7 @@ class Uniface(CppClass):
                                              cs.fetch_signature())
         return self._tags_fetch[tag][(fname_root, cs.signature, ss.signature)], ss, cs
 
-    def _get_fetch_6args(self, fname_root, tag, data_type, spatial_sampler, temporal_sampler):
+    def _get_fetch_6args_dual(self, fname_root, tag, data_type, spatial_sampler, temporal_sampler):
         assert issubclass(spatial_sampler.__class__, Sampler)
         assert issubclass(temporal_sampler.__class__, TemporalSampler)
         ss = None
@@ -309,13 +309,13 @@ class Uniface(CppClass):
             self._tags_temporal_samplers[tag][cs.signature] = cs
             rehash_fetch = True
         if rehash_fetch:
-            self._tags_fetch[tag][("fetch6", cs.signature, ss.signature)] = \
-                    "{}_{}_{}_{}".format("fetch",
+            self._tags_fetch[tag][("fetch_dual", cs.signature, ss.signature)] = \
+                    "{}_{}_{}_{}".format("fetch_dual",
                                          ALLOWED_IO_TYPES[data_type],
                                          ss.fetch_signature(),
                                          cs.fetch_signature())
-            self._tags_fetch[tag][("fetch_many6", cs.signature, ss.signature)] = \
-                "{}_{}_{}_{}".format("fetch_many6",
+            self._tags_fetch[tag][("fetch_many_dual", cs.signature, ss.signature)] = \
+                "{}_{}_{}_{}".format("fetch_many_dual",
                                      ALLOWED_IO_TYPES[data_type],
                                      ss.fetch_signature(),
                                      cs.fetch_signature())
@@ -327,24 +327,36 @@ class Uniface(CppClass):
         fetch_points = getattr(self.raw, "fetch_points_" + ALLOWED_IO_TYPES[data_type])
         return fetch_points(tag, time)
 
-    def fetch_many(self, tag, points, time, spatial_sampler, temporal_sampler):
-        fetch_fname, ss, cs = self._get_fetch_5args("fetch_many", tag, points.dtype.type,
+    def fetch_many(self, *args, **kwargs):
+        tag = args[0]
+        points = args[1]
+        time = args[2]
+        if len(args) == 5:
+            spatial_sampler = args[3]
+            temporal_sampler = args[4]
+            fetch_fname, ss, cs = self._get_fetch_5args("fetch_many", tag, points.dtype.type,
+                                                        spatial_sampler, temporal_sampler)
+            fetch = getattr(self.raw, fetch_fname)
+            return fetch(tag, points, time, ss.raw, cs.raw)
+        if len(args) == 6:
+            if isinstance(args[3], (FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64)):
+              time2 = args[3]
+              spatial_sampler = args[4]
+              temporal_sampler = args[5]
+              fetch_fname, ss, cs = self._get_fetch_6args_dual("fetch_many_dual", tag, points.dtype.type,
                                                     spatial_sampler, temporal_sampler)
-        fetch = getattr(self.raw, fetch_fname)
-        return fetch(tag, points, time, ss.raw, cs.raw)
-
-    def fetch_many6(self, tag, points, time1, time2, spatial_sampler, temporal_sampler):
-        fetch_fname, ss, cs = self._get_fetch_6args("fetch_many6", tag, points.dtype.type,
-                                                    spatial_sampler, temporal_sampler)
-        fetch = getattr(self.raw, fetch_fname)
-        return fetch(tag, points, time1, time2, ss.raw, cs.raw)
+              fetch = getattr(self.raw, fetch_fname)
+              return fetch(tag, points, time, time2, ss.raw, cs.raw)
+            else:
+                # 6 args, but args[3] is not time type, which means the last arg is coupling algo. To be implemented.
+                pass
 
     def fetch(self, *args, **kwargs):
         tag = args[0]
         data_type = map_type[self._get_tag_type(tag)]
         if len(args) == 1:
-            fetch_fname = "fetch_" + ALLOWED_IO_TYPES[data_type]
-            fargs = (tag, )
+            fetch_fname = "fetch_single_" + ALLOWED_IO_TYPES[data_type]
+            fargs = (tag)
         if len(args) == 5:
             loc = array2Point(args[1], self.config, self.raw_point)
             time = args[2]
@@ -360,22 +372,24 @@ class Uniface(CppClass):
                 raise Exception("Unrecognized time type '{}'.".format(type(time).__name__))
             fargs = (tag, loc, time, ss.raw, cs.raw, barrier_enabled)
         if len(args) == 6:
-            loc = array2Point(args[1], self.config, self.raw_point)
-            time1 = args[2]
-            time2 = args[3]
-            spatial_sampler = args[4]
-            temporal_sampler = args[5]
-            fetch_fname, ss, cs = self._get_fetch_6args("fetch", tag, data_type, spatial_sampler, temporal_sampler)
-            barrier_enabled = True
-            if type(time1).__name__ == 'float':
-                barrier_time = mui4py_mod.numeric_limits_real
-            elif type(time1).__name__ == 'int':
-                barrier_time = mui4py_mod.numeric_limits_int
+            if isinstance(args[3], (FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64)):
+                loc = array2Point(args[1], self.config, self.raw_point)
+                time1 = args[2]
+                time2 = args[3]
+                spatial_sampler = args[4]
+                temporal_sampler = args[5]
+                fetch_fname, ss, cs = self._get_fetch_6args_dual("fetch_dual", tag, data_type, spatial_sampler, temporal_sampler)
+                barrier_enabled = True
+                if type(time1).__name__ == 'float':
+                    barrier_time = mui4py_mod.numeric_limits_real
+                elif type(time1).__name__ == 'int':
+                    barrier_time = mui4py_mod.numeric_limits_int
+                else:
+                    raise Exception("Unrecognized time1 type '{}'.".format(type(time1).__name__))
+                fargs = (tag, loc, time1, time2, ss.raw, cs.raw, barrier_enabled)
             else:
-                raise Exception("Unrecognized time1 type '{}'.".format(type(time1).__name__))
-            if type(time1).__name__ != type(time2).__name__:
-                raise Exception("time1 type '{}'. doesn't same as time2 type".format(type(time1).__name__))
-            fargs = (tag, loc, time1, time2, ss.raw, cs.raw, barrier_enabled)
+                # 6 args, but args[3] is not time type, which means the last arg is coupling algo. To be implemented.
+                pass
         fetch = getattr(self.raw, fetch_fname)
         return safe_cast(self._get_tag_type(tag), fetch(*fargs))
 

--- a/wrappers/Python/mui4py/samplers.py
+++ b/wrappers/Python/mui4py/samplers.py
@@ -2,7 +2,7 @@
 ##############################################################################
 # Multiscale Universal Interface Code Coupling Library                       #
 #                                                                            #
-# Copyright (C) 2023 E. R. Fernandez                                         #
+# Copyright (C) 2023 E. R. Fernandez, W. Liu                                 #
 #                                                                            #
 # This software is jointly licensed under the Apache License, Version 2.0    #
 # and the GNU General Public License version 3, you may use it according     #
@@ -39,7 +39,7 @@
 ##############################################################################
 #
 # @file samplers.py
-# @author E. R. Fernandez
+# @author E. R. Fernandez, W. Liu
 # @date 25 January 2019
 # @brief Sampler functions for the MUI Python wrapper.
 #
@@ -47,7 +47,7 @@
 
 from mui4py.common import CppClass
 from mui4py.config import Config
-from mui4py.types import INT, FLOAT, FLOAT32, FLOAT64, INT32, INT64, STRING
+from mui4py.types import UINT, UINT32, UINT64, FLOAT, FLOAT32, FLOAT64, INT, INT32, INT64, STRING, BOOL
 
 # Inteface for Sampler and TemporalSampler
 def sampler_fetch_signature(self):
@@ -69,55 +69,55 @@ Sampler.fetch_signature = sampler_fetch_signature
 class SamplerExact(Sampler):
     def __init__(self, tol=None):
         super(SamplerExact, self).__init__(kwargs={"tol": tol})
-        self._ALLOWED_IO_TYPES = [FLOAT, INT, INT32, INT64, FLOAT32, FLOAT64, STRING]
+        self._ALLOWED_IO_TYPES = [FLOAT, INT, INT32, INT64, UINT, UINT32, UINT64, FLOAT32, FLOAT64, STRING, BOOL]
 
 
 class SamplerGauss(Sampler):
     def __init__(self, r, h):
         super(SamplerGauss, self).__init__(args=(r, h))
-        self._ALLOWED_IO_TYPES = [INT32, INT64, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
 
 
 class SamplerMovingAverage(Sampler):
     def __init__(self, bbox):
         super(SamplerMovingAverage, self).__init__(args=(_Point(bbox), ))
-        self._ALLOWED_IO_TYPES = [INT32, INT64, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
 
 
 class SamplerNearestNeighbor(Sampler):
     def __init__(self, r, h):
         super(SamplerNearestNeighbor, self).__init__(args=(r, h))
-        self._ALLOWED_IO_TYPES = [INT32, INT64, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
 
 
 class SamplerPseudoNearest2Linear(Sampler):
     def __init__(self, h):
         super(SamplerPseudoNearest2Linear, self).__init__(args=(h, ))
-        self._ALLOWED_IO_TYPES = [INT32, INT64, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
 
 
 class SamplerPseudoNearestNeighbor(Sampler):
     def __init__(self, h):
         super(SamplerPseudoNearestNeighbor, self).__init__(args=(h,))
-        self._ALLOWED_IO_TYPES = [INT32, INT64, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
 
 
 class SamplerSherpardQuintic(Sampler):
     def __init__(self, r):
         super(SamplerSherpardQuintic, self).__init__(args=(r,))
-        self._ALLOWED_IO_TYPES = [INT32, INT64, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
 
 
 class SamplerSphQuintic(Sampler):
     def __init__(self, r):
         super(SamplerSphQuintic, self).__init__(args=(r,))
-        self._ALLOWED_IO_TYPES = [INT32, INT64, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
 
 
 class SamplerSumQuintic(Sampler):
     def __init__(self, r):
         super(SamplerSumQuintic, self).__init__(args=(r,))
-        self._ALLOWED_IO_TYPES = [INT32, INT64, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
 
 
 class SamplerRbf(Sampler, CppClass):
@@ -128,7 +128,7 @@ class SamplerRbf(Sampler, CppClass):
                                          conservative, polynomial, smoothFunc,
                                          cutoff, cgSolveTol, cgMaxIter, pouSize, precond, 
                                          mpiComm))
-        self._ALLOWED_IO_TYPES = [INT32, INT64, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
 
 # Temporal samplers
 class TemporalSampler(CppClass):
@@ -143,22 +143,22 @@ TemporalSampler.fetch_signature = sampler_fetch_signature
 class TemporalSamplerExact(TemporalSampler):
     def __init__(self, tol=None):
         super(TemporalSamplerExact, self).__init__(kwargs={"tol": tol})
-        self._ALLOWED_IO_TYPES = [INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64, STRING]
+        self._ALLOWED_IO_TYPES = [INT, INT32, INT64, UINT, UINT32, UINT64, FLOAT, FLOAT32, FLOAT64, STRING, BOOL]
 
 
 class TemporalSamplerGauss(TemporalSampler):
     def __init__(self, cutoff, sigma):
         super(TemporalSamplerGauss, self).__init__(args=(cutoff, sigma))
-        self._ALLOWED_IO_TYPES = [INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]
 
 
 class TemporalSamplerMean(TemporalSampler):
     def __init__(self, newleft=None, newright=None):
         super(TemporalSamplerMean, self).__init__(kwargs={"newleft": newleft, "newright": newright})
-        self._ALLOWED_IO_TYPES = [INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]
 
 
 class TemporalSamplerSum(TemporalSampler):
     def __init__(self, newleft=None, newright=None):
         super(TemporalSamplerSum, self).__init__(kwargs={"newleft": newleft, "newright": newright})
-        self._ALLOWED_IO_TYPES = [INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]
+        self._ALLOWED_IO_TYPES = [UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]

--- a/wrappers/Python/mui4py/samplers.py
+++ b/wrappers/Python/mui4py/samplers.py
@@ -1,3 +1,4 @@
+"""
 ##############################################################################
 # Multiscale Universal Interface Code Coupling Library                       #
 #                                                                            #
@@ -42,6 +43,7 @@
 # @date 25 January 2019
 # @brief Sampler functions for the MUI Python wrapper.
 #
+"""
 
 from mui4py.common import CppClass
 from mui4py.config import Config

--- a/wrappers/Python/mui4py/samplers.py
+++ b/wrappers/Python/mui4py/samplers.py
@@ -1,3 +1,48 @@
+##############################################################################
+# Multiscale Universal Interface Code Coupling Library                       #
+#                                                                            #
+# Copyright (C) 2023 E. R. Fernandez                                         #
+#                                                                            #
+# This software is jointly licensed under the Apache License, Version 2.0    #
+# and the GNU General Public License version 3, you may use it according     #
+# to either.                                                                 #
+#                                                                            #
+# ** Apache License, version 2.0 **                                          #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License");            #
+# you may not use this file except in compliance with the License.           #
+# You may obtain a copy of the License at                                    #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#                                                                            #
+# ** GNU General Public License, version 3 **                                #
+#                                                                            #
+# This program is free software: you can redistribute it and/or modify       #
+# it under the terms of the GNU General Public License as published by       #
+# the Free Software Foundation, either version 3 of the License, or          #
+# (at your option) any later version.                                        #
+#                                                                            #
+# This program is distributed in the hope that it will be useful,            #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              #
+# GNU General Public License for more details.                               #
+#                                                                            #
+# You should have received a copy of the GNU General Public License          #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.      #
+##############################################################################
+#
+# @file samplers.py
+# @author E. R. Fernandez
+# @date 25 January 2019
+# @brief Sampler functions for the MUI Python wrapper.
+#
+
 from mui4py.common import CppClass
 from mui4py.config import Config
 from mui4py.types import INT, FLOAT, FLOAT32, FLOAT64, INT32, INT64, STRING

--- a/wrappers/Python/mui4py/types.py
+++ b/wrappers/Python/mui4py/types.py
@@ -1,3 +1,4 @@
+"""
 ##############################################################################
 # Multiscale Universal Interface Code Coupling Library                       #
 #                                                                            #
@@ -42,6 +43,7 @@
 # @date 25 January 2019
 # @brief Data type functions for the MUI Python wrapper.
 #
+"""
 
 import numpy as np
 

--- a/wrappers/Python/mui4py/types.py
+++ b/wrappers/Python/mui4py/types.py
@@ -1,3 +1,48 @@
+##############################################################################
+# Multiscale Universal Interface Code Coupling Library                       #
+#                                                                            #
+# Copyright (C) 2023 E. R. Fernandez                                         #
+#                                                                            #
+# This software is jointly licensed under the Apache License, Version 2.0    #
+# and the GNU General Public License version 3, you may use it according     #
+# to either.                                                                 #
+#                                                                            #
+# ** Apache License, version 2.0 **                                          #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License");            #
+# you may not use this file except in compliance with the License.           #
+# You may obtain a copy of the License at                                    #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#                                                                            #
+# ** GNU General Public License, version 3 **                                #
+#                                                                            #
+# This program is free software: you can redistribute it and/or modify       #
+# it under the terms of the GNU General Public License as published by       #
+# the Free Software Foundation, either version 3 of the License, or          #
+# (at your option) any later version.                                        #
+#                                                                            #
+# This program is distributed in the hope that it will be useful,            #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              #
+# GNU General Public License for more details.                               #
+#                                                                            #
+# You should have received a copy of the GNU General Public License          #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.      #
+##############################################################################
+#
+# @file types.py
+# @author E. R. Fernandez
+# @date 25 January 2019
+# @brief Data type functions for the MUI Python wrapper.
+#
+
 import numpy as np
 
 # Type enumeration

--- a/wrappers/Python/mui4py/types.py
+++ b/wrappers/Python/mui4py/types.py
@@ -2,7 +2,7 @@
 ##############################################################################
 # Multiscale Universal Interface Code Coupling Library                       #
 #                                                                            #
-# Copyright (C) 2023 E. R. Fernandez                                         #
+# Copyright (C) 2023 E. R. Fernandez, W. Liu                                 #
 #                                                                            #
 # This software is jointly licensed under the Apache License, Version 2.0    #
 # and the GNU General Public License version 3, you may use it according     #
@@ -39,7 +39,7 @@
 ##############################################################################
 #
 # @file types.py
-# @author E. R. Fernandez
+# @author E. R. Fernandez, W. Liu
 # @date 25 January 2019
 # @brief Data type functions for the MUI Python wrapper.
 #

--- a/wrappers/Python/mui4py/types.py
+++ b/wrappers/Python/mui4py/types.py
@@ -6,6 +6,9 @@ BOOL = bool
 INT32 = np.int32
 INT64 = np.int64
 INT = int
+UINT32 = np.uint32
+UINT64 = np.uint64
+UINT = UINT64
 FLOAT32 = np.float32
 FLOAT64 = np.float64
 FLOAT = float
@@ -13,6 +16,8 @@ FLOAT = float
 map_type = {STRING: STRING, BOOL: BOOL,
             INT32: INT32, INT64: INT64,
             INT: INT64,
+            UINT32: UINT32, UINT64: UINT64,
+            UINT: UINT64,
             FLOAT32: FLOAT32, FLOAT64: FLOAT64,
             FLOAT: FLOAT64,
             None: None}
@@ -20,6 +25,9 @@ map_type = {STRING: STRING, BOOL: BOOL,
 __int_size = int(str(np.iinfo(int).dtype)[-2:])
 if __int_size == 32:
     map_type[INT] = INT32
+__uint_size = int(str(np.iinfo(int).dtype)[-2:])
+if __uint_size == 32:
+    _map_type[UINT] = UINT32
 __float_size = int(str(np.finfo(float).dtype)[-2:])
 if __float_size == 32:
     map_type[FLOAT] = FLOAT32
@@ -27,15 +35,19 @@ assert __int_size in [32, 64]
 assert __float_size in [32, 64]
 __io_float_map = {64: "double", 32: "float"}
 __io_int_map = {64: "int64_t", 32: "int32_t"}
+__io_uint_map = {64: "uint64_t", 32: "uint32_t"}
 
 # Types allowed for configuring the library
 ALLOWED_INT_TYPES = {INT32: "i32", INT64: "i64"}  # , int: "i%d" % __int_size}
+ALLOWED_UINT_TYPES = {UINT32: "u32", UINT64: "u64"} #, uint: "i%d" % __int_size}
 ALLOWED_FLOAT_TYPES = {FLOAT32: "f32", FLOAT64: "f64"}  # , float: "f%d" % __float_size}
 
 # Types allowed to be pushed/fetched
 ALLOWED_IO_TYPES = {FLOAT32: "float", FLOAT64: "double",
                     INT32: "int32_t", INT64: "int64_t",
+                    UINT32: "uint32_t", UINT64: "uint64_t",
                     FLOAT: __io_float_map[__float_size],
+                    UINT: __io_uint_map[__int_size],
                     INT: __io_int_map[__int_size],
                     str: "string"}
 
@@ -46,6 +58,11 @@ def get_int_type_str(typein):
     else:
         raise Exception("Integer type '{}' not supported. Supported types : [int, np.int32, np.int64]".format(typein))
 
+def get_uint_type_str(typein):
+    if typein in ALLOWED_UINT_TYPES.keys():
+        return ALLOWED_UINT_TYPES[typein]
+    else:
+        pass
 
 def get_float_type_str(typein):
     if typein in ALLOWED_FLOAT_TYPES.keys():
@@ -53,7 +70,6 @@ def get_float_type_str(typein):
     else:
         raise Exception("Float type '{}' not supported. "
                         "Supported types : [float, np.float32, np.float64]".format(typein))
-
 
 def get_io_type_str(typein):
     if typein in ALLOWED_IO_TYPES.keys():

--- a/wrappers/Python/setup.py
+++ b/wrappers/Python/setup.py
@@ -1,3 +1,4 @@
+"""
 ##############################################################################
 # Multiscale Universal Interface Code Coupling Library                       #
 #                                                                            #
@@ -42,6 +43,7 @@
 # @date 20 January 2023
 # @brief Setup file for MUI Python wrapper.
 #
+"""
 
 import sys
 import os

--- a/wrappers/Python/setup.py
+++ b/wrappers/Python/setup.py
@@ -1,3 +1,48 @@
+##############################################################################
+# Multiscale Universal Interface Code Coupling Library                       #
+#                                                                            #
+# Copyright (C) 2023 C. Richardson, E. R. Fernandez                          #
+#                                                                            #
+# This software is jointly licensed under the Apache License, Version 2.0    #
+# and the GNU General Public License version 3, you may use it according     #
+# to either.                                                                 #
+#                                                                            #
+# ** Apache License, version 2.0 **                                          #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License");            #
+# you may not use this file except in compliance with the License.           #
+# You may obtain a copy of the License at                                    #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#                                                                            #
+# ** GNU General Public License, version 3 **                                #
+#                                                                            #
+# This program is free software: you can redistribute it and/or modify       #
+# it under the terms of the GNU General Public License as published by       #
+# the Free Software Foundation, either version 3 of the License, or          #
+# (at your option) any later version.                                        #
+#                                                                            #
+# This program is distributed in the hope that it will be useful,            #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              #
+# GNU General Public License for more details.                               #
+#                                                                            #
+# You should have received a copy of the GNU General Public License          #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.      #
+##############################################################################
+#
+# @file setup.py
+# @author C. Richardson, E. R. Fernandez
+# @date 20 January 2023
+# @brief Setup file for MUI Python wrapper.
+#
+
 import sys
 import os
 import shlex
@@ -57,7 +102,7 @@ setup(
       version='1.2.4',
       description='Python bindings for MUI coupling library.',
       url='http://mxui.github.io',
-      author='Eduardo Ramos Fernandez',
+      author='Eduardo Ramos Fernandez, Chris Richardson',
       author_email='eduardo.rf159@gmail.com',
       license='GPLv3 or Apache v2.0',
       packages=['mui4py', 'mui4py.cpp'],


### PR DESCRIPTION
# MUI C++ Core Code
- Remove warning message when compiling `algo_fixed_relaxation` by adding `const` to `calculate_relaxed_value()` func.
A minor fix on core code before working on the Python wrapper. 
# MUI Python Wrapper
- Update CMakeLists.txt of Python wrapper to include CMAKE_CURRENT_SOURCE_DIR and CMAKE_INCLUDE_DIRECTORIES
- Update Python wrapper Readme in terms of installation
- Added license header to all Python wrapper files -- consistent with MUI core code
- Update the interface construction create_unifaces in Python wrapper by adding a default communicator arg. It allow users to pass their own communicator, which is consistent with the core code and is a true reflection of the underlying function in the Python wrapper. The default communicator arg is tested in 10-2-multiple-interfaces demo, in which code0.py passes the communicator as one of the `create_unifaces()` parameters and the `create_unifaces()` in code1.py does not have the communicator parameter. Please see the corresponding [Pull Request in MUI-demo](https://github.com/SLongshaw/MUI-demo/pull/1#issue-1612322295) for more details.
- Added UINT data type in the Python wrapper, for the iterator_type in the MUI core code
- Initial attempt to separate mui4py.cpp by creating uniface.cpp. Test the feasibility of memory reduction when building
- Split uniface.cpp into uniface1d.cpp, uniface2d.cpp, etc. along with uniface.h to save memory. The memory required drops from 16GB to 10GB.
- Added missing functions in the Python wrapper, such as `is_ready()`, overloaded `forget()`, `announce_send/recv_disable()`, etc.
# Future Works
- Update Python wrapper RBF functions when the RBF core code is ready
- Complete missing functions in the Python wrapper, including multiple time types, coupling algorithms, etc.
- Further split uniface.h to save more memory when building, to make it ready to implement multiple time types and coupling algorithms (if the present python wrapper requires 16GB memory to build, it will require 16 * 2 (single time fetch & multiple time fetch) * 3 (null coupling algorithm & fixedRelaxation & Aitken) = 96GB to build). Thus, reducing memory is necessary.
