### PR TITLE
Python wrapper -- Done

### DIFF
--- a/src/uniface.h
+++ b/src/uniface.h
@@ -366,11 +366,13 @@ public:
         return values;
     }
 
+
     template<typename TYPE, class TIME_SAMPLER>
     py::array_t<REAL, py::array::c_style>
-    fetch_points_np(const std::string& attr, const time_type t, const TIME_SAMPLER &t_sampler, bool barrier_enabled = true) {
+    fetch_points_np(const std::string& attr, const time_type t, const TIME_SAMPLER &t_sampler, bool barrier_enabled = true, TYPE test_value = static_cast<TYPE>(0)) {
         std::vector<point_type> points = fetch_points<TYPE>(attr, t, t_sampler, barrier_enabled);
         size_t n = points.size();
+        test_value += 1;
         py::array_t<REAL, py::array::c_style> points_np({n, n});
         auto points_np_arr = points_np.template mutable_unchecked<2>();
         for (std::size_t i = 0; i < n; i++)
@@ -381,9 +383,10 @@ public:
 
     template<typename TYPE, class TIME_SAMPLER>
     py::array_t<REAL, py::array::c_style>
-    fetch_points_np(const std::string& attr, const time_type t, const iterator_type it, const TIME_SAMPLER &t_sampler, bool barrier_enabled = true) {
+    fetch_points_np(const std::string& attr, const time_type t, const iterator_type it, const TIME_SAMPLER &t_sampler, bool barrier_enabled = true, TYPE test_value = static_cast<TYPE>(0)) {
         std::vector<point_type> points = fetch_points<TYPE>(attr, t, it, t_sampler, barrier_enabled);
         size_t n = points.size();
+        test_value += 1;
         py::array_t<REAL, py::array::c_style> points_np({n, n});
         auto points_np_arr = points_np.template mutable_unchecked<2>();
         for (std::size_t i = 0; i < n; i++)

--- a/src/uniface.h
+++ b/src/uniface.h
@@ -373,7 +373,7 @@ public:
         std::vector<point_type> points = fetch_points<TYPE>(attr, t, t_sampler, barrier_enabled);
         size_t n = points.size();
         test_value += 1;
-        py::array_t<REAL, py::array::c_style> points_np({n, n});
+        py::array_t<REAL, py::array::c_style> points_np({n, static_cast<size_t>(D)});
         auto points_np_arr = points_np.template mutable_unchecked<2>();
         for (std::size_t i = 0; i < n; i++)
             for (std::size_t j = 0; j < D; j++)
@@ -387,7 +387,7 @@ public:
         std::vector<point_type> points = fetch_points<TYPE>(attr, t, it, t_sampler, barrier_enabled);
         size_t n = points.size();
         test_value += 1;
-        py::array_t<REAL, py::array::c_style> points_np({n, n});
+        py::array_t<REAL, py::array::c_style> points_np({n, static_cast<size_t>(D)});
         auto points_np_arr = points_np.template mutable_unchecked<2>();
         for (std::size_t i = 0; i < n; i++)
             for (std::size_t j = 0; j < D; j++)

--- a/wrappers/Python/mui4py/cpp/uniface_base.h
+++ b/wrappers/Python/mui4py/cpp/uniface_base.h
@@ -153,7 +153,9 @@ void declare_uniface_fetch_points(py::class_<mui::uniface<Tconfig>> &uniface)
               (py::array_t<Treal, py::array::c_style>(Tclass::*)(
                   const std::string &,
 				  const Ttime,
-                  const Ttemporal<Tconfig> &, bool)) &
+                  const Ttemporal<Tconfig> &,
+				  bool,
+				  T)) &
                   Tclass::fetch_points_np,
               "");
 }
@@ -172,7 +174,9 @@ void declare_uniface_fetch_points_dual(py::class_<mui::uniface<Tconfig>> &unifac
                   const std::string &,
 				  const Ttime,
 				  const Titer,
-                  const Ttemporal<Tconfig> &, bool)) &
+                  const Ttemporal<Tconfig> &,
+				  bool,
+				  T)) &
                   Tclass::fetch_points_np,
               "");
 }
@@ -185,10 +189,11 @@ void declare_uniface_fetch_values(py::class_<mui::uniface<Tconfig>> &uniface)
 
   std::string fetch_name = "fetch_values_" + type_name<T>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
   uniface.def(fetch_name.c_str(),
-              (py::array_t<T, py::array::c_style>(Tclass::*)(
+              (std::vector<T>(Tclass::*)(
                   const std::string &,
 				  const Ttime,
-                  const Ttemporal<Tconfig> &, bool)) &
+                  const Ttemporal<Tconfig> &,
+				  bool)) &
                   Tclass::fetch_values,
               "");
 }
@@ -202,11 +207,12 @@ void declare_uniface_fetch_values_dual(py::class_<mui::uniface<Tconfig>> &unifac
 
   std::string fetch_name = "fetch_values_dual_" + type_name<T>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>();
   uniface.def(fetch_name.c_str(),
-              (py::array_t<T, py::array::c_style>(Tclass::*)(
+              (std::vector<T>(Tclass::*)(
                   const std::string &,
 				  const Ttime,
 				  const Titer,
-                  const Ttemporal<Tconfig> &, bool)) &
+                  const Ttemporal<Tconfig> &,
+				  bool)) &
                   Tclass::fetch_values,
               "");
 }

--- a/wrappers/Python/mui4py/mui4py.py
+++ b/wrappers/Python/mui4py/mui4py.py
@@ -399,7 +399,7 @@ class Uniface(CppClass):
         data_type = map_type[self._get_tag_type(tag)]
         if len(args) == 1:
             fetch_fname = "fetch_single_" + ALLOWED_IO_TYPES[data_type]
-            fargs = (tag)
+            fargs = (tag,)
         elif len(args) == 5:
             loc = array2Point(args[1], self.config, self.raw_point)
             time = args[2]

--- a/wrappers/Python/mui4py/mui4py.py
+++ b/wrappers/Python/mui4py/mui4py.py
@@ -333,7 +333,7 @@ class Uniface(CppClass):
             temporal_sampler = args[2]
             barrier_enabled = args[3]
             test_value = args[4]
-            fetch_Pname, cs = self._get_fetch_points_values_args("fetch_points", tag, test_value.dtype.type, temporal_sampler)
+            fetch_Pname, cs = self._get_fetch_points_values_args("fetch_points", tag, type(test_value), temporal_sampler)
             fetch_points = getattr(self.raw, fetch_Pname)
             return fetch_points(tag, time, cs.raw, barrier_enabled, test_value)
         elif len(args) == 6:
@@ -341,7 +341,7 @@ class Uniface(CppClass):
             temporal_sampler = args[3]
             barrier_enabled = args[4]
             test_value = args[5]
-            fetch_Pname, cs = self._get_fetch_points_values_args("fetch_points_dual", tag, test_value.dtype.type, temporal_sampler)
+            fetch_Pname, cs = self._get_fetch_points_values_args("fetch_points_dual", tag, type(test_value), temporal_sampler)
             fetch_points = getattr(self.raw, fetch_Pname)
             return fetch_points(tag, time, iterator, cs.raw, barrier_enabled, test_value)
         else:
@@ -354,7 +354,7 @@ class Uniface(CppClass):
             temporal_sampler = args[2]
             barrier_enabled = args[3]
             test_value = args[4]
-            fetch_Pname, cs = self._get_fetch_points_values_args("fetch_values", tag, test_value.dtype.type, temporal_sampler)
+            fetch_Pname, cs = self._get_fetch_points_values_args("fetch_values", tag, type(test_value), temporal_sampler)
             fetch_values = getattr(self.raw, fetch_Pname)
             return fetch_values(tag, time, cs.raw, barrier_enabled)
         elif len(args) == 6:
@@ -362,7 +362,7 @@ class Uniface(CppClass):
             temporal_sampler = args[3]
             barrier_enabled = args[4]
             test_value = args[5]
-            fetch_Pname, cs = self._get_fetch_points_values_args("fetch_values_dual", tag, test_value.dtype.type, temporal_sampler)
+            fetch_Pname, cs = self._get_fetch_points_values_args("fetch_values_dual", tag, type(test_value), temporal_sampler)
             fetch_values = getattr(self.raw, fetch_Pname)
             return fetch_values(tag, time, iterator, cs.raw, barrier_enabled)
         else:


### PR DESCRIPTION
# What has been done on Python Wrapper
- finalised python wrapper with updates of `fetch_points()` and `fetch_value()` functions
- fixed bugs on `fetch_single()` function

# Tests
- The Python Wrapper code has been tested by Python wrapper demos (with [MUI-demo Pull Request #2](https://github.com/SLongshaw/MUI-demo/pull/2) merged).

# Memory usage during installation of the latest MUI Python Wrapper
There are two ways to build the MUI Python wrapper as indicated in MUI Python Wrapper ReadMe
- Method One: ```pip install .```

By using this method to build, the maximum memory usage is about 12.6GB.

- Method Two: ```cmake .. && make ```

By using this method to build, the maximum memory usage is about 5.5GB.

# Notes and future work
## Notes and Remarks
- The work related to MUI Python Wrapper towards v2.0 release is considered complete by merging this pull request.
- All possible top-level API functions in uniface.h has been implemented in the Python Wrapper.
- Both single time type and dual time types have been implemented.
- Memory requirement for installation has been reduced by file splitting.
- The interface construction function `create_unifaces()` in the Python wrapper has default arg to accept user-defined MPI communicator.  
 ## Future works
- Coupling algorithms haven't been implemented in Python Wrapper. They haven't been implemented in any wrappers yet. I will do it for all wrappers after creating this pull request, and this piece of work is considered a separate work (i.e. separate branch in my repo) rather than a part of this python wrapper work.
- I haven't touched the RBF-related parts in the Python wrapper, since the RBF core code needs an update before it can be used. Again, this piece of work is considered a separate work. All wrappers (including related demos) need an update once the RBF core code is ready.
- The central cmakelists.txt hasn't been tested in terms of python wrapper installation. Only the local cmakelists.txt inside the python wrapper folder has been extensively tested in all installation methods.



