### PR TITLE
RBF C++ fix

### DIFF
--- a/src/linear_algebra/preconditioner.h
+++ b/src/linear_algebra/preconditioner.h
@@ -128,7 +128,7 @@ class diagonal_preconditioner : public preconditioner<ITYPE,VTYPE> {
         sparse_matrix<ITYPE,VTYPE> apply(const sparse_matrix<ITYPE,VTYPE>&);
 
     private:
-        // The coefficient matrix of the matrix equation
+        // The inverse diagonal matrix
         sparse_matrix<ITYPE,VTYPE> inv_diag_;
 
 };

--- a/src/linear_algebra/solver.h
+++ b/src/linear_algebra/solver.h
@@ -96,12 +96,13 @@ class conjugate_gradient_1d : public solver<ITYPE,VTYPE> {
         sparse_matrix<ITYPE,VTYPE> z_;
         // The direction matrix of the CG solver
         sparse_matrix<ITYPE,VTYPE> p_;
-        // Preconditioner pointer
-        preconditioner<ITYPE,VTYPE>* M_;
         // Tolerance of CG solver
         VTYPE cg_solve_tol_;
         // Maximum iteration of CG solver
         ITYPE cg_max_iter_;
+        // Preconditioner pointer
+        preconditioner<ITYPE,VTYPE>* M_;
+
 };
 
 // Class of multidimensional Conjugate Gradient solver
@@ -129,12 +130,13 @@ class conjugate_gradient : public solver<ITYPE,VTYPE> {
         sparse_matrix<ITYPE,VTYPE> x_init_column_;
         // The variable matrix of the matrix equation
         sparse_matrix<ITYPE,VTYPE> x_;
-        // Preconditioner pointer
-        preconditioner<ITYPE,VTYPE>* M_;
         // Tolerance of CG solver
         VTYPE cg_solve_tol_;
         // Maximum iteration of CG solver
         ITYPE cg_max_iter_;
+        // Preconditioner pointer
+        preconditioner<ITYPE,VTYPE>* M_;
+
 };
 
 // Class of one-dimensional Gaussian Elimination solver

--- a/src/linear_algebra/test/solver.cpp
+++ b/src/linear_algebra/test/solver.cpp
@@ -767,6 +767,178 @@ void test06 () {
 
 }
 
+
+void test07 () {
+
+    std::cout << std::endl;
+    std::cout << "============================================================" << std::endl;
+    std::cout << "= TEST 07: 6-by-6 Matrix A with multidimensional Matrix b ==" << std::endl;
+    std::cout << "================== MUI Conjugate Gradient Solver ===========" << std::endl;
+    std::cout << "=================== Diagonal Preconditioner ================" << std::endl;
+    std::cout << "====================== with Initial Guess ==================" << std::endl;
+    std::cout << "============================================================" << std::endl;
+    std::cout << std::endl;
+
+    std::pair<int, double> cgReturn;
+
+    int Css_size = 6;
+    int Aas_size = 6;
+    double cg_solve_tol = 1e-6;
+    int cg_max_iter = 1000;
+
+    mui::linalg::sparse_matrix<int,double> Css; //< Matrix of radial basis function evaluations between prescribed points
+    mui::linalg::sparse_matrix<int,double> Aas; //< Matrix of RBF evaluations between prescribed and interpolation points
+    mui::linalg::sparse_matrix<int,double> H_init; //< Initial Transformation Matrix
+    mui::linalg::sparse_matrix<int,double> H_; //< Transformation Matrix
+    mui::linalg::sparse_matrix<int,double> H_ref; //< Reference value of Transformation Matrix
+    mui::linalg::sparse_matrix<int,double> H_diff; //< Difference between reference value and calculated value of Transformation Matrix
+
+    Css.resize_null(Css_size, Css_size);
+    Aas.resize_null(Aas_size, 4);
+    H_init.resize_null(Aas_size, 4);
+    H_.resize_null(Aas_size, 4);
+    H_ref.resize_null(Aas_size, 4);
+    H_diff.resize_null(Aas_size, 4);
+
+    H_init.set_value(0, 0, 9);
+    H_init.set_value(1, 0, 0);
+    H_init.set_value(2, 0, -2);
+    H_init.set_value(3, 0, 3);
+    H_init.set_value(4, 0, -2);
+    H_init.set_value(5, 0, 5);
+    H_init.set_value(0, 1, 9);
+    H_init.set_value(1, 1, 0);
+    H_init.set_value(2, 1, -2);
+    H_init.set_value(3, 1, 3);
+    H_init.set_value(4, 1, -2);
+    H_init.set_value(5, 1, 5);
+    H_init.set_value(0, 2, 9);
+    H_init.set_value(1, 2, 0);
+    H_init.set_value(2, 2, -2);
+    H_init.set_value(3, 2, 3);
+    H_init.set_value(4, 2, -2);
+    H_init.set_value(5, 2, 5);
+    H_init.set_value(0, 3, 9);
+    H_init.set_value(1, 3, 0);
+    H_init.set_value(2, 3, -2);
+    H_init.set_value(3, 3, 3);
+    H_init.set_value(4, 3, -2);
+    H_init.set_value(5, 3, 5);
+
+    H_ref.set_value(0, 0, 0.5488);
+    H_ref.set_value(1, 0, 0.7152);
+    H_ref.set_value(2, 0, 0.6028);
+    H_ref.set_value(3, 0, 0.5449);
+    H_ref.set_value(4, 0, 0.4237);
+    H_ref.set_value(5, 0, 0.6459);
+    H_ref.set_value(0, 1, 0.5488);
+    H_ref.set_value(1, 1, 0.7152);
+    H_ref.set_value(2, 1, 0.6028);
+    H_ref.set_value(3, 1, 0.5449);
+    H_ref.set_value(4, 1, 0.4237);
+    H_ref.set_value(5, 1, 0.6459);
+    H_ref.set_value(0, 2, 0.5488);
+    H_ref.set_value(1, 2, 0.7152);
+    H_ref.set_value(2, 2, 0.6028);
+    H_ref.set_value(3, 2, 0.5449);
+    H_ref.set_value(4, 2, 0.4237);
+    H_ref.set_value(5, 2, 0.6459);
+    H_ref.set_value(0, 3, 0.5488);
+    H_ref.set_value(1, 3, 0.7152);
+    H_ref.set_value(2, 3, 0.6028);
+    H_ref.set_value(3, 3, 0.5449);
+    H_ref.set_value(4, 3, 0.4237);
+    H_ref.set_value(5, 3, 0.6459);
+
+    Css.set_value(0, 0, 3.4430);
+    Css.set_value(0, 1, -0.3963);
+    Css.set_value(0, 2, 2.5012);
+    Css.set_value(0, 3, 0.9525);
+    Css.set_value(0, 4, 0.6084);
+    Css.set_value(0, 5, -1.2728);
+
+    Css.set_value(1, 0, -0.3963);
+    Css.set_value(1, 1, 0.6015);
+    Css.set_value(1, 2, -0.4108);
+    Css.set_value(1, 3, -0.1359);
+    Css.set_value(1, 4, -0.0295);
+    Css.set_value(1, 5, 0.2630);
+
+    Css.set_value(2, 0, 2.5012);
+    Css.set_value(2, 1, -0.4108);
+    Css.set_value(2, 2, 2.5927);
+    Css.set_value(2, 3, 0.7072);
+    Css.set_value(2, 4, 0.5587);
+    Css.set_value(2, 5, -1.0613);
+
+    Css.set_value(3, 0, 0.9525);
+    Css.set_value(3, 1, -0.1359);
+    Css.set_value(3, 2, 0.7072);
+    Css.set_value(3, 3, 1.1634);
+    Css.set_value(3, 4, 0.1920);
+    Css.set_value(3, 5, -0.4344);
+
+    Css.set_value(4, 0, 0.6084);
+    Css.set_value(4, 1, -0.0295);
+    Css.set_value(4, 2, 0.5587);
+    Css.set_value(4, 3, 0.1920);
+    Css.set_value(4, 4, 0.7636);
+    Css.set_value(4, 5, -0.3261);
+
+    Css.set_value(5, 0, -1.2728);
+    Css.set_value(5, 1, 0.2630);
+    Css.set_value(5, 2, -1.0613);
+    Css.set_value(5, 3, -0.4344);
+    Css.set_value(5, 4, -0.3261);
+    Css.set_value(5, 5, 1.0869);
+
+    Aas.set_value(0, 0, 3.0685);
+    Aas.set_value(1, 0, 0.0484);
+    Aas.set_value(2, 0, 2.5783);
+    Aas.set_value(3, 0, 1.2865);
+    Aas.set_value(4, 0, 0.8671);
+    Aas.set_value(5, 0, -0.8230);
+    Aas.set_value(0, 1, 3.0685);
+    Aas.set_value(1, 1, 0.0484);
+    Aas.set_value(2, 1, 2.5783);
+    Aas.set_value(3, 1, 1.2865);
+    Aas.set_value(4, 1, 0.8671);
+    Aas.set_value(5, 1, -0.8230);
+    Aas.set_value(0, 2, 3.0685);
+    Aas.set_value(1, 2, 0.0484);
+    Aas.set_value(2, 2, 2.5783);
+    Aas.set_value(3, 2, 1.2865);
+    Aas.set_value(4, 2, 0.8671);
+    Aas.set_value(5, 2, -0.8230);
+    Aas.set_value(0, 3, 3.0685);
+    Aas.set_value(1, 3, 0.0484);
+    Aas.set_value(2, 3, 2.5783);
+    Aas.set_value(3, 3, 1.2865);
+    Aas.set_value(4, 3, 0.8671);
+    Aas.set_value(5, 3, -0.8230);
+
+    mui::linalg::diagonal_preconditioner<int,double> M(Css);
+    mui::linalg::conjugate_gradient<int,double> cg(Css, Aas, cg_solve_tol, cg_max_iter, &M);
+    cgReturn = cg.solve(H_init);
+    H_ = cg.getSolution();
+
+    std::cout << "Matrix H_: " << std::endl;
+    H_.print();
+
+    std::cout << "Reference value of Matrix H_: " << std::endl;
+    H_ref.print();
+
+    H_diff = H_ - H_ref;
+
+    std::cout << "Difference between calculated value and reference value: " << std::endl;
+    H_diff.print();
+
+    std::cout << "Total CG iteration number: " << cgReturn.first <<" with final r_norm_rel: " << cgReturn.second << std::endl;
+
+    std::cout << std::endl;
+
+}
+
 int main() {
 
     // Perform test 00
@@ -783,6 +955,8 @@ int main() {
     test05();
     // Perform test 06
     test06();
+    // Perform test 07
+    test07();
 
     return 0;
 }

--- a/src/samplers/algorithm/algo_aitken.h
+++ b/src/samplers/algorithm/algo_aitken.h
@@ -374,7 +374,7 @@ public:
 
                                 assert(pts_time_res_iter != std::end(pts_time_res_) );
 
-                                if(pts_time_res_iter->second.size() != pts_residual_l2_norm_iter->second.first) {
+                                if(pts_time_res_iter->second.size() != static_cast<size_t>(pts_residual_l2_norm_iter->second.first)) {
 
                                     REAL local_residual_mag_sq_sum_temp = 0.0;
                                     REAL residual_mag_sq_sum_temp = 0.0;
@@ -688,7 +688,7 @@ private:
 
 						assert(pts_time_res_nm2_iter != std::end(pts_time_res_) );
 
-						if(pts_time_res_nm2_iter->second.size() != res_l2_norm_nm2_iter->second.first) {
+						if(pts_time_res_nm2_iter->second.size() != static_cast<size_t>(res_l2_norm_nm2_iter->second.first)) {
 
 							REAL local_residual_mag_sq_sum_temp = 0.0;
 							REAL residual_mag_sq_sum_temp = 0.0;
@@ -715,7 +715,7 @@ private:
 
 						assert(pts_time_res_nm1_iter != std::end(pts_time_res_) );
 
-						if(pts_time_res_nm1_iter->second.size() != res_l2_norm_nm1_iter->second.first) {
+						if(pts_time_res_nm1_iter->second.size() != static_cast<size_t>(res_l2_norm_nm1_iter->second.first)) {
 
 							REAL local_residual_mag_sq_sum_temp = 0.0;
 							REAL residual_mag_sq_sum_temp = 0.0;
@@ -826,7 +826,7 @@ private:
 
 						assert(pts_time_res_nm2_iter != std::end(pts_time_res_) );
 
-						if(pts_time_res_nm2_iter->second.size() != res_l2_norm_nm2_iter->second.first) {
+						if(pts_time_res_nm2_iter->second.size() != static_cast<size_t>(res_l2_norm_nm2_iter->second.first)) {
 
 							REAL local_residual_mag_sq_sum_temp = 0.0;
 							REAL residual_mag_sq_sum_temp = 0.0;
@@ -852,7 +852,7 @@ private:
 
 						assert(pts_time_res_nm1_iter != std::end(pts_time_res_) );
 
-						if(pts_time_res_nm1_iter->second.size() != res_l2_norm_nm1_iter->second.first) {
+						if(pts_time_res_nm1_iter->second.size() != static_cast<size_t>(res_l2_norm_nm1_iter->second.first)) {
 
 							REAL local_residual_mag_sq_sum_temp = 0.0;
 							REAL residual_mag_sq_sum_temp = 0.0;
@@ -934,11 +934,11 @@ private:
     }
 
 protected:
-    MPI_Comm local_mpi_comm_world_;
-
     const REAL init_under_relaxation_factor_;
 
     const REAL under_relaxation_factor_max_;
+
+    MPI_Comm local_mpi_comm_world_;
 
     iterator_type minimum_iterator_;
 

--- a/src/samplers/spatial/sampler_rbf.h
+++ b/src/samplers/spatial/sampler_rbf.h
@@ -574,7 +574,7 @@ public:
 							return b.first == xGhostPointsCountToSend.first;
 						});
 
-				assert(ghostPointsToSendIter->second.size() == xGhostPointsCountToSend.second);
+				assert(ghostPointsToSendIter->second.size() == static_cast<size_t>(xGhostPointsCountToSend.second));
 
 				int buffer_size = ghostPointsToSendIter->second.size() * sizeof(point_type);
 				char *buffer = new char[buffer_size];
@@ -842,8 +842,8 @@ private:
 			Aas.resize_null((1 + NP + CONFIG::D), 1);
 
 			//set Css
-			for (INT i = 0; i < NP; i++) {
-				for (INT j = i; j < NP; j++) {
+			for (size_t i = 0; i < NP; i++) {
+				for (size_t j = i; j < NP; j++) {
 					int glob_i = connectivityAB_[row][i];
 					int glob_j = connectivityAB_[row][j];
 
@@ -860,7 +860,7 @@ private:
 				}
 			}
 
-			for (INT i = 0; i < NP; i++) {
+			for (size_t i = 0; i < NP; i++) {
 				Css.set_value(i, NP, 1);
 				Css.set_value(NP, i, 1);
 
@@ -875,7 +875,7 @@ private:
 			}
 
 			//set Aas
-			for (INT j = 0; j < NP; j++) {
+			for (size_t j = 0; j < NP; j++) {
 				int glob_j = connectivityAB_[row][j];
 
 				auto d = norm(ptsExtend_[row] - data_points[glob_j].first);
@@ -1170,7 +1170,7 @@ private:
 
 		for (size_t i = 0; i < ptsExtend_.size(); i++) {
 			INT pointsCount = 0;
-			for (INT n = 0; n < NP; n++) {
+			for (size_t n = 0; n < NP; n++) {
 				REAL cur = std::numeric_limits<REAL>::max();
 				INT bestj = -1;
 				for (size_t j = 0; j < data_points.size(); j++) {
@@ -1318,7 +1318,7 @@ private:
 		connectivityAA_.resize(ptsExtend_.size());
 
 		for (size_t i = 0; i < ptsExtend_.size(); i++) {
-			for (INT n = 0; n < MP; n++) {
+			for (size_t n = 0; n < MP; n++) {
 				REAL cur = std::numeric_limits<REAL>::max();
 				INT bestj = -1;
 				for (size_t j = 0; j < ptsExtend_.size(); j++) {
@@ -1544,9 +1544,9 @@ protected:
 	const bool conservative_;
 	const bool consistent_;
 	const bool smoothFunc_;
-	INT precond_;
 	const bool writeMatrix_;
 	const std::string writeFileAddress_;
+	INT precond_;
 	mutable bool initialised_;
 	MPI_Comm local_mpi_comm_world_;
 	mutable INT CABrow_;
@@ -1556,6 +1556,7 @@ protected:
 	bool pouEnabled_;
 	REAL cgSolveTol_;
 	INT cgMaxIter_;
+
 	mutable size_t N_sp_;
 	mutable size_t M_ap_;
 	int local_rank_;

--- a/src/uniface.h
+++ b/src/uniface.h
@@ -335,7 +335,7 @@ public:
     template<class SAMPLER, class TIME_SAMPLER>
     py::array_t<typename SAMPLER::OTYPE,py::array::c_style>
     fetch_many(const std::string& attr,const py::array_t<REAL,py::array::c_style> points, const time_type t,
-           SAMPLER& sampler, const TIME_SAMPLER &t_sampler) {
+        const SAMPLER &sampler, const TIME_SAMPLER &t_sampler, bool barrier_enabled = true) {
         // Arrays must have ndim = d; can be non-writeable
         point_type p = 0;
         auto points_arr = points.template unchecked<2>();
@@ -344,7 +344,7 @@ public:
         for (ssize_t i = 0; i < points_arr.shape(0); i++) {
             for (ssize_t j = 0; j < points_arr.shape(1); j++)
                 p[j] = points_arr(i,j);
-            values_arr(i)  = fetch(attr, p, t, sampler, t_sampler);
+            values_arr(i)  = fetch(attr, p, t, sampler, t_sampler, barrier_enabled);
         }
         return values;
     }
@@ -352,7 +352,7 @@ public:
     template<class SAMPLER, class TIME_SAMPLER>
     py::array_t<typename SAMPLER::OTYPE,py::array::c_style>
     fetch_many(const std::string& attr,const py::array_t<REAL,py::array::c_style> points, const time_type t,
-        const iterator_type it, SAMPLER& sampler, const TIME_SAMPLER &t_sampler) {
+        const iterator_type it, const SAMPLER &sampler, const TIME_SAMPLER &t_sampler, bool barrier_enabled = true) {
         // Arrays must have ndim = d; can be non-writeable
         point_type p = 0;
         auto points_arr = points.template unchecked<2>();
@@ -361,7 +361,41 @@ public:
         for (ssize_t i = 0; i < points_arr.shape(0); i++) {
             for (ssize_t j = 0; j < points_arr.shape(1); j++)
                 p[j] = points_arr(i,j);
-            values_arr(i)  = fetch(attr, p, t, it, sampler, t_sampler);
+            values_arr(i)  = fetch(attr, p, t, it, sampler, t_sampler, barrier_enabled);
+        }
+        return values;
+    }
+
+    template<class SAMPLER, class TIME_SAMPLER, class ALGORITHM>
+    py::array_t<typename SAMPLER::OTYPE,py::array::c_style>
+    fetch_many(const std::string& attr,const py::array_t<REAL,py::array::c_style> points, const time_type t,
+        const SAMPLER &sampler, const TIME_SAMPLER &t_sampler, const ALGORITHM &algorithm, bool barrier_enabled = true) {
+        // Arrays must have ndim = d; can be non-writeable
+        point_type p = 0;
+        auto points_arr = points.template unchecked<2>();
+        py::array_t<typename SAMPLER::OTYPE,py::array::c_style> values(points_arr.shape(0));
+        auto values_arr = values.template mutable_unchecked<1>();
+        for (ssize_t i = 0; i < points_arr.shape(0); i++) {
+            for (ssize_t j = 0; j < points_arr.shape(1); j++)
+                p[j] = points_arr(i,j);
+            values_arr(i)  = fetch(attr, p, t, sampler, t_sampler, algorithm, barrier_enabled);
+        }
+        return values;
+    }
+
+    template<class SAMPLER, class TIME_SAMPLER, class ALGORITHM>
+    py::array_t<typename SAMPLER::OTYPE,py::array::c_style>
+    fetch_many(const std::string& attr,const py::array_t<REAL,py::array::c_style> points, const time_type t,
+        const iterator_type it, const SAMPLER &sampler, const TIME_SAMPLER &t_sampler, const ALGORITHM &algorithm, bool barrier_enabled = true) {
+        // Arrays must have ndim = d; can be non-writeable
+        point_type p = 0;
+        auto points_arr = points.template unchecked<2>();
+        py::array_t<typename SAMPLER::OTYPE,py::array::c_style> values(points_arr.shape(0));
+        auto values_arr = values.template mutable_unchecked<1>();
+        for (ssize_t i = 0; i < points_arr.shape(0); i++) {
+            for (ssize_t j = 0; j < points_arr.shape(1); j++)
+                p[j] = points_arr(i,j);
+            values_arr(i)  = fetch(attr, p, t, it, sampler, t_sampler, algorithm, barrier_enabled);
         }
         return values;
     }

--- a/wrappers/C/Makefile
+++ b/wrappers/C/Makefile
@@ -11,8 +11,8 @@ CXXFLAGS = -O3 -std=c++11 -fpic
 
 default: mui_c_wrapper_general.o mui_c_wrapper_1d.o mui_c_wrapper_2d.o mui_c_wrapper_3d.o
 	 @echo "Compiling and linking MUI C wrapper..."
-	 ${CCX} ${CFLAGS} -shared -o libmui_c_wrapper.so mui_c_wrapper_general.o mui_c_wrapper_1d.o mui_c_wrapper_2d.o mui_c_wrapper_3d.o
-	 ${AR} rcs libmui_c_wrapper.a mui_c_wrapper_general.o mui_c_wrapper_1d.o mui_c_wrapper_2d.o mui_c_wrapper_3d.o
+	 ${CCX} ${CFLAGS} -shared -o libMUI_C_wrapper.so mui_c_wrapper_general.o mui_c_wrapper_1d.o mui_c_wrapper_2d.o mui_c_wrapper_3d.o
+	 ${AR} rcs libMUI_C_wrapper.a mui_c_wrapper_general.o mui_c_wrapper_1d.o mui_c_wrapper_2d.o mui_c_wrapper_3d.o
 
 mui_c_wrapper_general.o: mui_c_wrapper_general.cpp
 	 @echo "Generating C-wrapper general functions object file..."
@@ -32,8 +32,8 @@ mui_c_wrapper_3d.o: mui_c_wrapper_3d.cpp
 
 test:
 	 @echo "Compiling and linking MUI C wrapper unit test code..."
-	 ${CC} ${CFLAGS} unit_test_single.c -o unit_test_c_wrapper_single -L${PWD} libmui_c_wrapper.a -lstdc++ -lmpi_cxx -lm
-	 ${CC} ${CFLAGS} unit_test_multi.c -o unit_test_c_wrapper_multi -L${PWD} libmui_c_wrapper.a -lstdc++ -lmpi_cxx -lm
+	 ${CC} ${CFLAGS} unit_test_single.c -o unit_test_c_wrapper_single -L${PWD} libMUI_C_wrapper.a -lstdc++ -lmpi_cxx -lm
+	 ${CC} ${CFLAGS} unit_test_multi.c -o unit_test_c_wrapper_multi -L${PWD} libMUI_C_wrapper.a -lstdc++ -lmpi_cxx -lm
 	 @echo "Launching C wrapper unit test code for single interface creation..."
 	 ${MPI} -np 1 ./unit_test_c_wrapper_single domain1 interface : -np 1 ./unit_test_c_wrapper_single domain2 interface
 	 @echo "Launching C wrapper unit test code for multi interface creation..."

--- a/wrappers/C/mui_c_wrapper_1d.cpp
+++ b/wrappers/C/mui_c_wrapper_1d.cpp
@@ -214,6 +214,24 @@ typedef mui::temporal_sampler_sum1dx mui_temporal_sampler_sum_1dx;
 // Summation temporal sampler typedefs for template creation (recommended)
 typedef mui::temporal_sampler_sum<mui::mui_c_wrapper_1D> mui_temporal_sampler_sum_1t;
 
+// Fixed relaxation algorithm typedefs for specialism creation
+typedef mui::algo_fixed_relaxation1f mui_algorithm_fixed_relaxation_1f;
+typedef mui::algo_fixed_relaxation1fx mui_algorithm_fixed_relaxation_1fx;
+typedef mui::algo_fixed_relaxation1d mui_algorithm_fixed_relaxation_1d;
+typedef mui::algo_fixed_relaxation1dx mui_algorithm_fixed_relaxation_1dx;
+
+// Fixed relaxation algorithm typedefs for template creation (recommended)
+typedef mui::algo_fixed_relaxation<mui::mui_c_wrapper_1D> mui_algorithm_fixed_relaxation_1t;
+
+// Aitken's algorithm typedefs for specialism creation
+typedef mui::algo_aitken1f mui_algorithm_aitken_1f;
+typedef mui::algo_aitken1fx mui_algorithm_aitken_1fx;
+typedef mui::algo_aitken1d mui_algorithm_aitken_1d;
+typedef mui::algo_aitken1dx mui_algorithm_aitken_1dx;
+
+// Aitken's algorithm typedefs for template creation (recommended)
+typedef mui::algo_aitken<mui::mui_c_wrapper_1D> mui_algorithm_aitken_1t;
+
 /****************************************
  * Create MUI interfaces                 *
  ****************************************/
@@ -1009,6 +1027,324 @@ void mui_destroy_temporal_sampler_sum_1dx(mui_temporal_sampler_sum_1dx *sampler)
 
 void mui_destroy_temporal_sampler_sum_1t(mui_temporal_sampler_sum_1t *sampler) {
 	delete sampler;
+}
+
+/*******************************************
+ * Create algorithms                       *
+ *******************************************/
+
+// Fixed relaxation algorithm
+mui_algorithm_fixed_relaxation_1f* mui_create_algorithm_fixed_relaxation_1f(float under_relaxation_factor = 1.0, mui_point_1f *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
+
+	std::vector<std::pair<mui::point1f, float>> pts_value_init;
+
+	if ((pair_count == 0) || (points == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1f, float>>();
+	} else {
+		pts_value_init.resize(pair_count);
+		for (size_t i = 0; i < pair_count; i++) {
+			mui::point1f pts;
+			pts[0] = points[i].point_1;
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+	return new mui_algorithm_fixed_relaxation_1f(under_relaxation_factor, pts_value_init);
+}
+
+mui_algorithm_fixed_relaxation_1fx* mui_create_algorithm_fixed_relaxation_1fx(float under_relaxation_factor = 1.0, mui_point_1fx *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
+
+	std::vector<std::pair<mui::point1fx, float>> pts_value_init;
+
+	if ((pair_count == 0) || (points == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1fx, float>>();
+	} else {
+		pts_value_init.resize(pair_count);
+		for (size_t i = 0; i < pair_count; i++) {
+			mui::point1fx pts;
+			pts[0] = points[i].point_1;
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+	return new mui_algorithm_fixed_relaxation_1fx(under_relaxation_factor, pts_value_init);
+}
+
+mui_algorithm_fixed_relaxation_1d* mui_create_algorithm_fixed_relaxation_1d(double under_relaxation_factor = 1.0, mui_point_1d *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+
+	std::vector<std::pair<mui::point1d, double>> pts_value_init;
+
+	if ((pair_count == 0) || (points == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1d, double>>();
+	} else {
+		pts_value_init.resize(pair_count);
+		for (size_t i = 0; i < pair_count; i++) {
+			mui::point1d pts;
+			pts[0] = points[i].point_1;
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+	return new mui_algorithm_fixed_relaxation_1d(under_relaxation_factor, pts_value_init);
+}
+
+mui_algorithm_fixed_relaxation_1dx* mui_create_algorithm_fixed_relaxation_1dx(double under_relaxation_factor = 1.0, mui_point_1dx *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+
+	std::vector<std::pair<mui::point1dx, double>> pts_value_init;
+
+	if ((pair_count == 0) || (points == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1dx, double>>();
+	} else {
+		pts_value_init.resize(pair_count);
+		for (size_t i = 0; i < pair_count; i++) {
+			mui::point1dx pts;
+			pts[0] = points[i].point_1;
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+	return new mui_algorithm_fixed_relaxation_1dx(under_relaxation_factor, pts_value_init);
+}
+
+mui_algorithm_fixed_relaxation_1t* mui_create_algorithm_fixed_relaxation_1t(double under_relaxation_factor = 1.0, mui_point_1t *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+
+	std::vector<std::pair<mui::mui_c_wrapper_1D::point_type, mui::mui_c_wrapper_1D::REAL>> pts_value_init;
+
+	if ((pair_count == 0) || (points == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::mui_c_wrapper_1D::point_type, mui::mui_c_wrapper_1D::REAL>>();
+	} else {
+		pts_value_init.resize(pair_count);
+		for (size_t i = 0; i < pair_count; i++) {
+			mui::mui_c_wrapper_1D::point_type pts;
+			pts[0] = points[i].point_1;
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+	return new mui_algorithm_fixed_relaxation_1t(static_cast<mui::mui_c_wrapper_1D::REAL>(under_relaxation_factor), pts_value_init);
+}
+
+// Aitken's algorithm
+mui_algorithm_aitken_1f* mui_create_algorithm_aitken_1f(float under_relaxation_factor = 1.0, float under_relaxation_factor_max = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_1f *points = nullptr, float *value_init = nullptr, int pair_count = 0, float res_l2_norm_nm1 = 0.0) {
+
+	std::vector<std::pair<mui::point1f, float>> pts_value_init;
+
+	if ((pair_count == 0) || (points == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1f, float>>();
+	} else {
+		pts_value_init.resize(pair_count);
+		for (size_t i = 0; i < pair_count; i++) {
+			mui::point1f pts;
+			pts[0] = points[i].point_1;
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+	return new mui_algorithm_aitken_1f(under_relaxation_factor, under_relaxation_factor_max, communicator, pts_value_init, res_l2_norm_nm1);
+}
+
+mui_algorithm_aitken_1fx* mui_create_algorithm_aitken_1fx(float under_relaxation_factor = 1.0, float under_relaxation_factor_max = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_1fx *points = nullptr, float *value_init = nullptr, int pair_count = 0, float res_l2_norm_nm1 = 0.0) {
+
+	std::vector<std::pair<mui::point1fx, float>> pts_value_init;
+
+	if ((pair_count == 0) || (points == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1fx, float>>();
+	} else {
+		pts_value_init.resize(pair_count);
+		for (size_t i = 0; i < pair_count; i++) {
+			mui::point1fx pts;
+			pts[0] = points[i].point_1;
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+	return new mui_algorithm_aitken_1fx(under_relaxation_factor, under_relaxation_factor_max, communicator, pts_value_init, res_l2_norm_nm1);
+}
+
+mui_algorithm_aitken_1d* mui_create_algorithm_aitken_1d(double under_relaxation_factor = 1.0, double under_relaxation_factor_max = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_1d *points = nullptr, double *value_init = nullptr, int pair_count = 0, double res_l2_norm_nm1 = 0.0) {
+
+	std::vector<std::pair<mui::point1d, double>> pts_value_init;
+
+	if ((pair_count == 0) || (points == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1d, double>>();
+	} else {
+		pts_value_init.resize(pair_count);
+		for (size_t i = 0; i < pair_count; i++) {
+			mui::point1d pts;
+			pts[0] = points[i].point_1;
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+	return new mui_algorithm_aitken_1d(under_relaxation_factor, under_relaxation_factor_max, communicator, pts_value_init, res_l2_norm_nm1);
+}
+
+mui_algorithm_aitken_1dx* mui_create_algorithm_aitken_1dx(double under_relaxation_factor = 1.0, double under_relaxation_factor_max = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_1dx *points = nullptr, double *value_init = nullptr, int pair_count = 0, double res_l2_norm_nm1 = 0.0) {
+
+	std::vector<std::pair<mui::point1dx, double>> pts_value_init;
+
+	if ((pair_count == 0) || (points == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1dx, double>>();
+	} else {
+		pts_value_init.resize(pair_count);
+		for (size_t i = 0; i < pair_count; i++) {
+			mui::point1dx pts;
+			pts[0] = points[i].point_1;
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+	return new mui_algorithm_aitken_1dx(under_relaxation_factor, under_relaxation_factor_max, communicator, pts_value_init, res_l2_norm_nm1);
+}
+
+mui_algorithm_aitken_1t* mui_create_algorithm_aitken_1t(double under_relaxation_factor = 1.0, double under_relaxation_factor_max = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_1t *points = nullptr, double *value_init = nullptr, int pair_count = 0, double res_l2_norm_nm1 = 0.0) {
+
+	std::vector<std::pair<mui::mui_c_wrapper_1D::point_type, mui::mui_c_wrapper_1D::REAL>> pts_value_init;
+
+	if ((pair_count == 0) || (points == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::mui_c_wrapper_1D::point_type, mui::mui_c_wrapper_1D::REAL>>();
+	} else {
+		pts_value_init.resize(pair_count);
+		for (size_t i = 0; i < pair_count; i++) {
+			mui::mui_c_wrapper_1D::point_type pts;
+			pts[0] = points[i].point_1;
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+	return new mui_algorithm_aitken_1t(static_cast<mui::mui_c_wrapper_1D::REAL>(under_relaxation_factor), static_cast<mui::mui_c_wrapper_1D::REAL>(under_relaxation_factor_max), communicator, pts_value_init, static_cast<mui::mui_c_wrapper_1D::REAL>(res_l2_norm_nm1));
+}
+
+/*******************************************
+ * Aitken's functions for get info         *
+ *******************************************/
+
+// Aitken's get under relaxation factor functions
+float mui_aitken_get_under_relaxation_factor_1f(mui_algorithm_aitken_1f *aitken, float t) {
+	return aitken->get_under_relaxation_factor(t);
+}
+
+float mui_aitken_get_under_relaxation_factor_1fx(mui_algorithm_aitken_1fx *aitken, float t) {
+	return aitken->get_under_relaxation_factor(t);
+}
+
+double mui_aitken_get_under_relaxation_factor_1d(mui_algorithm_aitken_1d *aitken, double t) {
+	return aitken->get_under_relaxation_factor(t);
+}
+
+double mui_aitken_get_under_relaxation_factor_1dx(mui_algorithm_aitken_1dx *aitken, double t) {
+	return aitken->get_under_relaxation_factor(t);
+}
+
+double mui_aitken_get_under_relaxation_factor_1t(mui_algorithm_aitken_1t *aitken, double t) {
+	return aitken->get_under_relaxation_factor(static_cast<mui::mui_c_wrapper_1D::time_type>(t));
+}
+
+float mui_aitken_get_under_relaxation_factor_1f_pair(mui_algorithm_aitken_1f *aitken, float t, float it) {
+	return aitken->get_under_relaxation_factor(t, it);
+}
+
+float mui_aitken_get_under_relaxation_factor_1fx_pair(mui_algorithm_aitken_1fx *aitken, float t, float it) {
+	return aitken->get_under_relaxation_factor(t, it);
+}
+
+double mui_aitken_get_under_relaxation_factor_1d_pair(mui_algorithm_aitken_1d *aitken, double t, double it) {
+	return aitken->get_under_relaxation_factor(t, it);
+}
+
+double mui_aitken_get_under_relaxation_factor_1dx_pair(mui_algorithm_aitken_1dx *aitken, double t, double it) {
+	return aitken->get_under_relaxation_factor(t, it);
+}
+
+double mui_aitken_get_under_relaxation_factor_1t_pair(mui_algorithm_aitken_1t *aitken, double t, double it) {
+	return aitken->get_under_relaxation_factor(static_cast<mui::mui_c_wrapper_1D::time_type>(t),
+			static_cast<mui::mui_c_wrapper_1D::iterator_type>(it));
+}
+
+// Aitken's get under relaxation factor functions
+float mui_aitken_get_residual_L2_Norm_1f(mui_algorithm_aitken_1f *aitken, float t) {
+	return aitken->get_residual_L2_Norm(t);
+}
+
+float mui_aitken_get_residual_L2_Norm_1fx(mui_algorithm_aitken_1fx *aitken, float t) {
+	return aitken->get_residual_L2_Norm(t);
+}
+
+double mui_aitken_get_residual_L2_Norm_1d(mui_algorithm_aitken_1d *aitken, double t) {
+	return aitken->get_residual_L2_Norm(t);
+}
+
+double mui_aitken_get_residual_L2_Norm_1dx(mui_algorithm_aitken_1dx *aitken, double t) {
+	return aitken->get_residual_L2_Norm(t);
+}
+
+double mui_aitken_get_residual_L2_Norm_1t(mui_algorithm_aitken_1t *aitken, double t) {
+	return aitken->get_residual_L2_Norm(static_cast<mui::mui_c_wrapper_1D::time_type>(t));
+}
+
+float mui_aitken_get_residual_L2_Norm_1f_pair(mui_algorithm_aitken_1f *aitken, float t, float it) {
+	return aitken->get_residual_L2_Norm(t, it);
+}
+
+float mui_aitken_get_residual_L2_Norm_1fx_pair(mui_algorithm_aitken_1fx *aitken, float t, float it) {
+	return aitken->get_residual_L2_Norm(t, it);
+}
+
+double mui_aitken_get_residual_L2_Norm_1d_pair(mui_algorithm_aitken_1d *aitken, double t, double it) {
+	return aitken->get_residual_L2_Norm(t, it);
+}
+
+double mui_aitken_get_residual_L2_Norm_1dx_pair(mui_algorithm_aitken_1dx *aitken, double t, double it) {
+	return aitken->get_residual_L2_Norm(t, it);
+}
+
+double mui_aitken_get_residual_L2_Norm_1t_pair(mui_algorithm_aitken_1t *aitken, double t, double it) {
+	return aitken->get_residual_L2_Norm(static_cast<mui::mui_c_wrapper_1D::time_type>(t),
+			static_cast<mui::mui_c_wrapper_1D::iterator_type>(it));
+}
+
+/*******************************************
+ * Destroy algorithms                      *
+ *******************************************/
+
+void mui_destroy_algorithm_fixed_relaxation_1f(mui_algorithm_fixed_relaxation_1f *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_fixed_relaxation_1fx(mui_algorithm_fixed_relaxation_1fx *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_fixed_relaxation_1d(mui_algorithm_fixed_relaxation_1d *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_fixed_relaxation_1dx(mui_algorithm_fixed_relaxation_1dx *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_fixed_relaxation_1t(mui_algorithm_fixed_relaxation_1t *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_aitken_1f(mui_algorithm_aitken_1f *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_aitken_1fx(mui_algorithm_aitken_1fx *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_aitken_1d(mui_algorithm_aitken_1d *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_aitken_1dx(mui_algorithm_aitken_1dx *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_aitken_1t(mui_algorithm_aitken_1t *algorithm) {
+	delete algorithm;
 }
 
 /******************************************
@@ -3359,6 +3695,4450 @@ double mui_fetch_rbf_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_
 			*spatial_sampler, *temporal_sampler));
 	return result;
 }
+
+
+/************************************************************************
+ * MUI functions for 1D data fetch with algorithms using one time value *
+ ************************************************************************/
+
+// Spatial sampler: exact; temporal sampler: exact; algorithm: fixed relaxation
+float mui_fetch_exact_exact_fixed_relaxation_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1f *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+float mui_fetch_exact_exact_fixed_relaxation_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1fx *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_fixed_relaxation_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1d *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_fixed_relaxation_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1dx *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_fixed_relaxation_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1t *algorithm) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler, *algorithm));
+	return result;
+}
+/*
+// Spatial sampler: exact; temporal sampler: gauss
+float mui_fetch_exact_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: exact; temporal sampler: mean
+float mui_fetch_exact_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: exact; temporal sampler: sum
+float mui_fetch_exact_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+} result;
+}
+
+// Spatial sampler: gauss; temporal sampler: exact
+float mui_fetch_gauss_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: gauss; temporal sampler: gauss
+float mui_fetch_gauss_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: gauss; temporal sampler: mean
+float mui_fetch_gauss_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: exact
+float mui_fetch_moving_average_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: gauss
+float mui_fetch_moving_average_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: mean
+float mui_fetch_moving_average_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: sum
+float mui_fetch_moving_average_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+float mui_fetch_nearest_neighbor_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+float mui_fetch_nearest_neighbor_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+float mui_fetch_nearest_neighbor_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+float mui_fetch_nearest_neighbor_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+*/
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+float mui_fetch_pseudo_nearest_neighbor_exact_fixed_relaxation_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1f *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_exact_fixed_relaxation_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_exact_1fx *temporal_sampler, mui_algorithm_fixed_relaxation_1fx *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_fixed_relaxation_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_exact_1d *temporal_sampler, mui_algorithm_fixed_relaxation_1d *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_fixed_relaxation_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_exact_1dx *temporal_sampler, mui_algorithm_fixed_relaxation_1dx *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_fixed_relaxation_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_exact_1t *temporal_sampler, mui_algorithm_fixed_relaxation_1t *algorithm) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler, *algorithm));
+	return result;
+}
+/*
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+float mui_fetch_pseudo_nearest_neighbor_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+float mui_fetch_pseudo_nearest_neighbor_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+float mui_fetch_pseudo_nearest_neighbor_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: exact
+float mui_fetch_shepard_quintic_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: gauss
+float mui_fetch_shepard_quintic_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: mean
+float mui_fetch_shepard_quintic_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: sum
+float mui_fetch_shepard_quintic_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: exact
+float mui_fetch_sph_quintic_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: gauss
+float mui_fetch_sph_quintic_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: mean
+float mui_fetch_sph_quintic_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: sum
+float mui_fetch_sph_quintic_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: exact
+float mui_fetch_sum_quintic_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: gauss
+float mui_fetch_sum_quintic_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: mean
+float mui_fetch_sum_quintic_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: sum
+float mui_fetch_sum_quintic_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: exact
+float mui_fetch_rbf_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: gauss
+float mui_fetch_rbf_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: mean
+float mui_fetch_rbf_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: sum
+float mui_fetch_rbf_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+*/
+
+
+// Spatial sampler: exact; temporal sampler: exact; algorithm: aitken
+float mui_fetch_exact_exact_aitken_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_aitken_1f *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+float mui_fetch_exact_exact_aitken_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_aitken_1fx *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_aitken_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_aitken_1d *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_aitken_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_aitken_1dx *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_aitken_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_aitken_1t *algorithm) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler, *algorithm));
+	return result;
+}
+
+/*
+// Spatial sampler: exact; temporal sampler: gauss
+float mui_fetch_exact_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: exact; temporal sampler: mean
+float mui_fetch_exact_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: exact; temporal sampler: sum
+float mui_fetch_exact_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+} result;
+}
+
+// Spatial sampler: gauss; temporal sampler: exact
+float mui_fetch_gauss_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: gauss; temporal sampler: gauss
+float mui_fetch_gauss_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: gauss; temporal sampler: mean
+float mui_fetch_gauss_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: exact
+float mui_fetch_moving_average_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: gauss
+float mui_fetch_moving_average_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: mean
+float mui_fetch_moving_average_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: sum
+float mui_fetch_moving_average_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+float mui_fetch_nearest_neighbor_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+float mui_fetch_nearest_neighbor_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+float mui_fetch_nearest_neighbor_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+float mui_fetch_nearest_neighbor_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+float mui_fetch_pseudo_nearest_neighbor_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+float mui_fetch_pseudo_nearest_neighbor_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+float mui_fetch_pseudo_nearest_neighbor_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+float mui_fetch_pseudo_nearest_neighbor_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: exact
+float mui_fetch_shepard_quintic_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: gauss
+float mui_fetch_shepard_quintic_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: mean
+float mui_fetch_shepard_quintic_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: sum
+float mui_fetch_shepard_quintic_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: exact
+float mui_fetch_sph_quintic_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: gauss
+float mui_fetch_sph_quintic_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: mean
+float mui_fetch_sph_quintic_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: sum
+float mui_fetch_sph_quintic_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: exact
+float mui_fetch_sum_quintic_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: gauss
+float mui_fetch_sum_quintic_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: mean
+float mui_fetch_sum_quintic_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: sum
+float mui_fetch_sum_quintic_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: exact
+float mui_fetch_rbf_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: gauss
+float mui_fetch_rbf_gauss_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_gauss_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: mean
+float mui_fetch_rbf_mean_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_mean_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: sum
+float mui_fetch_rbf_sum_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_sum_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), *spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+*/
+
+/**********************************************************************************
+ * MUI functions for 1D data fetch with algorithms using time and iterator values *
+ **********************************************************************************/
+
+// Spatial sampler: exact; temporal sampler: exact; algorithm: fixed relaxation
+float mui_fetch_exact_exact_fixed_relaxation_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1f *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+float mui_fetch_exact_exact_fixed_relaxation_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1fx *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_fixed_relaxation_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1d *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_fixed_relaxation_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1dx *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_fixed_relaxation_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1t *algorithm) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler, *algorithm));
+	return result;
+}
+/*
+// Spatial sampler: exact; temporal sampler: gauss
+float mui_fetch_exact_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: exact; temporal sampler: mean
+float mui_fetch_exact_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: exact; temporal sampler: sum
+float mui_fetch_exact_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: gauss; temporal sampler: exact
+float mui_fetch_gauss_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: gauss; temporal sampler: gauss
+float mui_fetch_gauss_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: gauss; temporal sampler: mean
+float mui_fetch_gauss_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: exact
+float mui_fetch_moving_average_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_moving_average_1fx *spatial_sampler,
+		mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_moving_average_1dx *spatial_sampler,
+		mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: gauss
+float mui_fetch_moving_average_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_moving_average_1fx *spatial_sampler,
+		mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_moving_average_1dx *spatial_sampler,
+		mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: mean
+float mui_fetch_moving_average_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_moving_average_1dx *spatial_sampler,
+		mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: sum
+float mui_fetch_moving_average_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_moving_average_1dx *spatial_sampler,
+		mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+float mui_fetch_nearest_neighbor_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+float mui_fetch_nearest_neighbor_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+float mui_fetch_nearest_neighbor_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+float mui_fetch_nearest_neighbor_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+float mui_fetch_pseudo_nearest_neighbor_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+		mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+float mui_fetch_pseudo_nearest_neighbor_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+		mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+float mui_fetch_pseudo_nearest_neighbor_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+		mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+float mui_fetch_pseudo_nearest_neighbor_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+		mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: exact
+float mui_fetch_shepard_quintic_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+		mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_shepard_quintic_1d *spatial_sampler,
+		mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+		mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_shepard_quintic_1t *spatial_sampler,
+		mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: gauss
+float mui_fetch_shepard_quintic_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+		mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_shepard_quintic_1d *spatial_sampler,
+		mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+		mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_shepard_quintic_1t *spatial_sampler,
+		mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: mean
+float mui_fetch_shepard_quintic_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+		mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+		mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: sum
+float mui_fetch_shepard_quintic_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+		mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: exact
+float mui_fetch_sph_quintic_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: gauss
+float mui_fetch_sph_quintic_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: mean
+float mui_fetch_sph_quintic_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: sum
+float mui_fetch_sph_quintic_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: exact
+float mui_fetch_sum_quintic_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: gauss
+float mui_fetch_sum_quintic_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: mean
+float mui_fetch_sum_quintic_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: sum
+float mui_fetch_sum_quintic_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: exact
+float mui_fetch_rbf_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: gauss
+float mui_fetch_rbf_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: mean
+float mui_fetch_rbf_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t, float it,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t, double it,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t, double it,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: sum
+float mui_fetch_rbf_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t, float it,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t, double it,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t, double it,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+*/
+
+// Spatial sampler: exact; temporal sampler: exact; algorithm: aitken
+float mui_fetch_exact_exact_aitken_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_aitken_1f *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+float mui_fetch_exact_exact_aitken_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_aitken_1fx *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_aitken_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_aitken_1d *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_aitken_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_aitken_1dx *algorithm) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler, *algorithm);
+}
+
+double mui_fetch_exact_exact_aitken_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_aitken_1t *algorithm) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler, *algorithm));
+	return result;
+}
+/*
+// Spatial sampler: exact; temporal sampler: gauss
+float mui_fetch_exact_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: exact; temporal sampler: mean
+float mui_fetch_exact_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: exact; temporal sampler: sum
+float mui_fetch_exact_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_exact_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_exact_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: gauss; temporal sampler: exact
+float mui_fetch_gauss_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: gauss; temporal sampler: gauss
+float mui_fetch_gauss_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: gauss; temporal sampler: mean
+float mui_fetch_gauss_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_gauss_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_gauss_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: exact
+float mui_fetch_moving_average_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_moving_average_1fx *spatial_sampler,
+		mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_moving_average_1dx *spatial_sampler,
+		mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: gauss
+float mui_fetch_moving_average_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_moving_average_1fx *spatial_sampler,
+		mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_moving_average_1dx *spatial_sampler,
+		mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: mean
+float mui_fetch_moving_average_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_moving_average_1dx *spatial_sampler,
+		mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: moving average; temporal sampler: sum
+float mui_fetch_moving_average_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_moving_average_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_moving_average_1dx *spatial_sampler,
+		mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_moving_average_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+float mui_fetch_nearest_neighbor_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+float mui_fetch_nearest_neighbor_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+float mui_fetch_nearest_neighbor_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+float mui_fetch_nearest_neighbor_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_nearest_neighbor_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_nearest_neighbor_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+float mui_fetch_pseudo_nearest_neighbor_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+		mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+float mui_fetch_pseudo_nearest_neighbor_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+		mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+float mui_fetch_pseudo_nearest_neighbor_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+		mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+float mui_fetch_pseudo_nearest_neighbor_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+		mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_pseudo_nearest_neighbor_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_pseudo_nearest_neighbor_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: exact
+float mui_fetch_shepard_quintic_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+		mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_shepard_quintic_1d *spatial_sampler,
+		mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+		mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_shepard_quintic_1t *spatial_sampler,
+		mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: gauss
+float mui_fetch_shepard_quintic_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+		mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, double it, mui_sampler_shepard_quintic_1d *spatial_sampler,
+		mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+		mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, double it, mui_sampler_shepard_quintic_1t *spatial_sampler,
+		mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: mean
+float mui_fetch_shepard_quintic_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, float it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+		mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+		mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: sum
+float mui_fetch_shepard_quintic_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_shepard_quintic_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, double it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+		mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_shepard_quintic_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: exact
+float mui_fetch_sph_quintic_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: gauss
+float mui_fetch_sph_quintic_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: mean
+float mui_fetch_sph_quintic_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: sum
+float mui_fetch_sph_quintic_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sph_quintic_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sph_quintic_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: exact
+float mui_fetch_sum_quintic_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: gauss
+float mui_fetch_sum_quintic_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: mean
+float mui_fetch_sum_quintic_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: summation quintic; temporal sampler: sum
+float mui_fetch_sum_quintic_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		float it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_sum_quintic_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_sum_quintic_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: exact
+float mui_fetch_rbf_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_exact_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: gauss
+float mui_fetch_rbf_gauss_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_gauss_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_gauss_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: mean
+float mui_fetch_rbf_mean_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_mean_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t, float it,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t, double it,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_mean_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t, double it,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+
+// Spatial sampler: radial basis function; temporal sampler: sum
+float mui_fetch_rbf_sum_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1f(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+float mui_fetch_rbf_sum_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t, float it,
+		mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1fx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t, double it,
+		mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1d(point.point_1), t, it, *spatial_sampler, *temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler) {
+	return uniface->fetch(std::string(attr), mui::point1dx(point.point_1), t, it, *spatial_sampler,
+			*temporal_sampler);
+}
+
+double mui_fetch_rbf_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t, double it,
+		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler) {
+	mui::mui_c_wrapper_1D::point_type point_fetch(static_cast<mui::mui_c_wrapper_1D::REAL>(point.point_1));
+	double result = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+			static_cast<mui::mui_c_wrapper_1D::time_type>(t), static_cast<mui::mui_c_wrapper_1D::iterator_type>(it),
+			*spatial_sampler, *temporal_sampler));
+	return result;
+}
+*/
 
 /*******************************************************************
  * MUI functions for 1D data point only fetch using one time value  *

--- a/wrappers/C/mui_c_wrapper_1d.h
+++ b/wrappers/C/mui_c_wrapper_1d.h
@@ -75,7 +75,7 @@ typedef struct mui_point_1t {
 	double point_1;
 } mui_point_1t;
 
-// C access typedefs for uniface and sampler types
+// C access typedefs for uniface, sampler types and algorithms
 typedef struct mui_uniface_1f mui_uniface_1f;
 typedef struct mui_uniface_1fx mui_uniface_1fx;
 typedef struct mui_uniface_1d mui_uniface_1d;
@@ -165,6 +165,18 @@ typedef struct mui_temporal_sampler_sum_1fx mui_temporal_sampler_sum_1fx;
 typedef struct mui_temporal_sampler_sum_1d mui_temporal_sampler_sum_1d;
 typedef struct mui_temporal_sampler_sum_1dx mui_temporal_sampler_sum_1dx;
 typedef struct mui_temporal_sampler_sum_1t mui_temporal_sampler_sum_1t;
+
+typedef struct mui_algorithm_fixed_relaxation_1f mui_algorithm_fixed_relaxation_1f;
+typedef struct mui_algorithm_fixed_relaxation_1fx mui_algorithm_fixed_relaxation_1fx;
+typedef struct mui_algorithm_fixed_relaxation_1d mui_algorithm_fixed_relaxation_1d;
+typedef struct mui_algorithm_fixed_relaxation_1dx mui_algorithm_fixed_relaxation_1dx;
+typedef struct mui_algorithm_fixed_relaxation_1t mui_algorithm_fixed_relaxation_1t;
+
+typedef struct mui_algorithm_aitken_1f mui_algorithm_aitken_1f;
+typedef struct mui_algorithm_aitken_1fx mui_algorithm_aitken_1fx;
+typedef struct mui_algorithm_aitken_1d mui_algorithm_aitken_1d;
+typedef struct mui_algorithm_aitken_1dx mui_algorithm_aitken_1dx;
+typedef struct mui_algorithm_aitken_1t mui_algorithm_aitken_1t;
 
 // MUI single uniface creation
 mui_uniface_1f* mui_create_uniface_1f(const char *URI);
@@ -345,6 +357,62 @@ void mui_destroy_temporal_sampler_sum_1d(mui_temporal_sampler_sum_1d *sampler);
 void mui_destroy_temporal_sampler_sum_1dx(mui_temporal_sampler_sum_1dx *sampler);
 void mui_destroy_temporal_sampler_sum_1t(mui_temporal_sampler_sum_1t *sampler);
 
+// MUI algorithms creation
+mui_algorithm_fixed_relaxation_1f* mui_create_algorithm_fixed_relaxation_1f(float under_relaxation_factor, mui_point_1f *points,
+		float *value_init, int pair_count);
+mui_algorithm_fixed_relaxation_1fx* mui_create_algorithm_fixed_relaxation_1fx(float under_relaxation_factor, mui_point_1fx *points,
+		float *value_init, int pair_count);
+mui_algorithm_fixed_relaxation_1d* mui_create_algorithm_fixed_relaxation_1d(double under_relaxation_factor, mui_point_1d *points,
+		double *value_init, int pair_count);
+mui_algorithm_fixed_relaxation_1dx* mui_create_algorithm_fixed_relaxation_1dx(double under_relaxation_factor, mui_point_1dx *points,
+		double *value_init, int pair_count);
+mui_algorithm_fixed_relaxation_1t* mui_create_algorithm_fixed_relaxation_1t(double under_relaxation_factor, mui_point_1t *points,
+		double *value_init, int pair_count);
+mui_algorithm_aitken_1f* mui_create_algorithm_aitken_1f(float under_relaxation_factor, float under_relaxation_factor_max,
+		MPI_Comm communicator, mui_point_1f *points, float *value_init, int pair_count, float res_l2_norm_nm1);
+mui_algorithm_aitken_1fx* mui_create_algorithm_aitken_1fx(float under_relaxation_factor, float under_relaxation_factor_max,
+		MPI_Comm communicator, mui_point_1fx *points, float *value_init, int pair_count, float res_l2_norm_nm1);
+mui_algorithm_aitken_1d* mui_create_algorithm_aitken_1d(double under_relaxation_factor, double under_relaxation_factor_max,
+		MPI_Comm communicator, mui_point_1d *points, double *value_init, int pair_count, double res_l2_norm_nm1);
+mui_algorithm_aitken_1dx* mui_create_algorithm_aitken_1dx(double under_relaxation_factor, double under_relaxation_factor_max,
+		MPI_Comm communicator, mui_point_1dx *points, double *value_init, int pair_count, double res_l2_norm_nm1);
+mui_algorithm_aitken_1t* mui_create_algorithm_aitken_1t(double under_relaxation_factor, double under_relaxation_factor_max,
+		MPI_Comm communicator, mui_point_1t *points, double *value_init, int pair_count, double res_l2_norm_nm1);
+
+// Aitken's algorithms functions for get info
+float mui_aitken_get_under_relaxation_factor_1f(mui_algorithm_aitken_1f *aitken, float t);
+float mui_aitken_get_under_relaxation_factor_1fx(mui_algorithm_aitken_1fx *aitken, float t);
+double mui_aitken_get_under_relaxation_factor_1d(mui_algorithm_aitken_1d *aitken, double t);
+double mui_aitken_get_under_relaxation_factor_1dx(mui_algorithm_aitken_1dx *aitken, double t);
+double mui_aitken_get_under_relaxation_factor_1t(mui_algorithm_aitken_1t *aitken, double t);
+float mui_aitken_get_under_relaxation_factor_1f_pair(mui_algorithm_aitken_1f *aitken, float t, float it);
+float mui_aitken_get_under_relaxation_factor_1fx_pair(mui_algorithm_aitken_1fx *aitken, float t, float it);
+double mui_aitken_get_under_relaxation_factor_1d_pair(mui_algorithm_aitken_1d *aitken, double t, double it);
+double mui_aitken_get_under_relaxation_factor_1dx_pair(mui_algorithm_aitken_1dx *aitken, double t, double it);
+double mui_aitken_get_under_relaxation_factor_1t_pair(mui_algorithm_aitken_1t *aitken, double t, double it);
+float mui_aitken_get_residual_L2_Norm_1f(mui_algorithm_aitken_1f *aitken, float t);
+float mui_aitken_get_residual_L2_Norm_1fx(mui_algorithm_aitken_1fx *aitken, float t);
+double mui_aitken_get_residual_L2_Norm_1d(mui_algorithm_aitken_1d *aitken, double t);
+double mui_aitken_get_residual_L2_Norm_1dx(mui_algorithm_aitken_1dx *aitken, double t);
+double mui_aitken_get_residual_L2_Norm_1t(mui_algorithm_aitken_1t *aitken, double t);
+float mui_aitken_get_residual_L2_Norm_1f_pair(mui_algorithm_aitken_1f *aitken, float t, float it);
+float mui_aitken_get_residual_L2_Norm_1fx_pair(mui_algorithm_aitken_1fx *aitken, float t, float it);
+double mui_aitken_get_residual_L2_Norm_1d_pair(mui_algorithm_aitken_1d *aitken, double t, double it);
+double mui_aitken_get_residual_L2_Norm_1dx_pair(mui_algorithm_aitken_1dx *aitken, double t, double it);
+double mui_aitken_get_residual_L2_Norm_1t_pair(mui_algorithm_aitken_1t *aitken, double t, double it);
+
+// MUI algorithms destruction
+void mui_destroy_algorithm_fixed_relaxation_1f(mui_algorithm_fixed_relaxation_1f *algorithm);
+void mui_destroy_algorithm_fixed_relaxation_1fx(mui_algorithm_fixed_relaxation_1fx *algorithm);
+void mui_destroy_algorithm_fixed_relaxation_1d(mui_algorithm_fixed_relaxation_1d *algorithm);
+void mui_destroy_algorithm_fixed_relaxation_1dx(mui_algorithm_fixed_relaxation_1dx *algorithm);
+void mui_destroy_algorithm_fixed_relaxation_1t(mui_algorithm_fixed_relaxation_1t *algorithm);
+void mui_destroy_algorithm_aitken_1f(mui_algorithm_aitken_1f *algorithm);
+void mui_destroy_algorithm_aitken_1fx(mui_algorithm_aitken_1fx *algorithm);
+void mui_destroy_algorithm_aitken_1d(mui_algorithm_aitken_1d *algorithm);
+void mui_destroy_algorithm_aitken_1dx(mui_algorithm_aitken_1dx *algorithm);
+void mui_destroy_algorithm_aitken_1t(mui_algorithm_aitken_1t *algorithm);
+
 // MUI functions for data push
 void mui_push_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float value);
 void mui_push_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float value);
@@ -381,7 +449,7 @@ void mui_forecast_1d_pair(mui_uniface_1d *uniface, double t, double it);
 void mui_forecast_1dx_pair(mui_uniface_1dx *uniface, double t, double it);
 void mui_forecast_1t_pair(mui_uniface_1t *uniface, double t, double it);
 
-// MUI functions for data fetch
+// MUI functions for data fetch using one time value
 float mui_fetch_exact_exact_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
 		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler);
 float mui_fetch_exact_exact_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
@@ -747,10 +815,7 @@ double mui_fetch_rbf_sum_1dx(mui_uniface_1dx *uniface, const char *attr, mui_poi
 double mui_fetch_rbf_sum_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
 		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler);
 
-/********************************************************
- * MUI functions for 1D data fetch using two time values *
- *********************************************************/
-
+// MUI functions for data fetch using two time values
 float mui_fetch_exact_exact_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
 		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler);
 float mui_fetch_exact_exact_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
@@ -1152,6 +1217,115 @@ double mui_fetch_rbf_sum_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mu
 		double it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler);
 double mui_fetch_rbf_sum_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t, double it,
 		mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler);
+
+// MUI functions for 1D data fetch with fixed relaxation algorithm using one time value
+float mui_fetch_exact_exact_fixed_relaxation_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1f *algorithm);
+float mui_fetch_exact_exact_fixed_relaxation_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1fx *algorithm);
+double mui_fetch_exact_exact_fixed_relaxation_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1d *algorithm);
+double mui_fetch_exact_exact_fixed_relaxation_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1dx *algorithm);
+double mui_fetch_exact_exact_fixed_relaxation_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1t *algorithm);
+
+
+
+
+
+float mui_fetch_pseudo_nearest_neighbor_exact_fixed_relaxation_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1f *algorithm);
+float mui_fetch_pseudo_nearest_neighbor_exact_fixed_relaxation_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point,
+		float t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+		mui_temporal_sampler_exact_1fx *temporal_sampler, mui_algorithm_fixed_relaxation_1fx *algorithm);
+double mui_fetch_pseudo_nearest_neighbor_exact_fixed_relaxation_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+		mui_temporal_sampler_exact_1d *temporal_sampler, mui_algorithm_fixed_relaxation_1d *algorithm);
+double mui_fetch_pseudo_nearest_neighbor_exact_fixed_relaxation_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+		mui_temporal_sampler_exact_1dx *temporal_sampler, mui_algorithm_fixed_relaxation_1dx *algorithm);
+double mui_fetch_pseudo_nearest_neighbor_exact_fixed_relaxation_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point,
+		double t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+		mui_temporal_sampler_exact_1t *temporal_sampler, mui_algorithm_fixed_relaxation_1t *algorithm);
+
+
+
+
+
+
+
+
+
+
+// MUI functions for 1D data fetch with aitken algorithm using one time value
+float mui_fetch_exact_exact_aitken_1f(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_aitken_1f *algorithm);
+float mui_fetch_exact_exact_aitken_1fx(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_aitken_1fx *algorithm);
+double mui_fetch_exact_exact_aitken_1d(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_aitken_1d *algorithm);
+double mui_fetch_exact_exact_aitken_1dx(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_aitken_1dx *algorithm);
+double mui_fetch_exact_exact_aitken_1t(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_aitken_1t *algorithm);
+
+
+
+
+
+// MUI functions for 1D data fetch with fixed relaxation algorithm using two time values
+float mui_fetch_exact_exact_fixed_relaxation_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1f *algorithm);
+float mui_fetch_exact_exact_fixed_relaxation_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1fx *algorithm);
+double mui_fetch_exact_exact_fixed_relaxation_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1d *algorithm);
+double mui_fetch_exact_exact_fixed_relaxation_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1dx *algorithm);
+double mui_fetch_exact_exact_fixed_relaxation_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1t *algorithm);
+
+
+
+
+
+// MUI functions for 1D data fetch with aitken algorithm using two time values
+float mui_fetch_exact_exact_aitken_1f_pair(mui_uniface_1f *uniface, const char *attr, mui_point_1f point, float t, float it,
+		mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_aitken_1f *algorithm);
+float mui_fetch_exact_exact_aitken_1fx_pair(mui_uniface_1fx *uniface, const char *attr, mui_point_1fx point, float t,
+		float it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_aitken_1fx *algorithm);
+double mui_fetch_exact_exact_aitken_1d_pair(mui_uniface_1d *uniface, const char *attr, mui_point_1d point, double t,
+		double it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_aitken_1d *algorithm);
+double mui_fetch_exact_exact_aitken_1dx_pair(mui_uniface_1dx *uniface, const char *attr, mui_point_1dx point, double t,
+		double it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_aitken_1dx *algorithm);
+double mui_fetch_exact_exact_aitken_1t_pair(mui_uniface_1t *uniface, const char *attr, mui_point_1t point, double t,
+		double it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_aitken_1t *algorithm);
+
+
+
+
 
 // MUI functions for 1D data point only fetch using single time value
 void mui_fetch_points_exact_1f(mui_uniface_1f *uniface, const char *attr, float t,

--- a/wrappers/Fortran/Makefile
+++ b/wrappers/Fortran/Makefile
@@ -11,8 +11,8 @@ CXXFLAGS = -O3 -std=c++11 -fpic -shared
 
 default: mui_f_wrapper_general.o mui_f_wrapper_1d.o mui_f_wrapper_2d.o mui_f_wrapper_3d.o mui_f_wrapper_general.mod mui_f_wrapper_1d.mod mui_f_wrapper_2d.mod mui_f_wrapper_3d.mod
 	 @echo "Compiling and linking MUI Fortran wrapper..."
-	 ${CCX} ${CXXFLAGS} -o libmui_f_wrapper.so mui_f_wrapper_general.o mui_f_wrapper_1d.o mui_f_wrapper_2d.o mui_f_wrapper_3d.o
-	 ${AR} rcs libmui_f_wrapper.a mui_f_wrapper_general.o mui_f_wrapper_1d.o mui_f_wrapper_2d.o mui_f_wrapper_3d.o
+	 ${CCX} ${CXXFLAGS} -o libMUI_Fortran_wrapper.so mui_f_wrapper_general.o mui_f_wrapper_1d.o mui_f_wrapper_2d.o mui_f_wrapper_3d.o
+	 ${AR} rcs libMUI_Fortran_wrapper.a mui_f_wrapper_general.o mui_f_wrapper_1d.o mui_f_wrapper_2d.o mui_f_wrapper_3d.o
 
 mui_f_wrapper_general.o: mui_f_wrapper_general.cpp
 	 @echo "Generating MUI Fortran wrapper general object file..."
@@ -48,8 +48,8 @@ mui_f_wrapper_3d.mod: mui_f_wrapper_3d.f90
 
 test:
 	 @echo "Compiling and linking MUI Fortran wrapper unit test code..."
-	 ${FC} ${FFLAGS} mui_f_wrapper_1d.f90 mui_f_wrapper_2d.f90 mui_f_wrapper_3d.f90 unit_test.f90 -o unit_test_fortran_wrapper -L. libmui_f_wrapper.a -lstdc++ -lmpi_cxx
-	 ${FC} ${FFLAGS} mui_f_wrapper_1d.f90 mui_f_wrapper_2d.f90 mui_f_wrapper_3d.f90 unit_test_multi.f90 -o unit_test_multi_fortran_wrapper -L. libmui_f_wrapper.a -lstdc++ -lmpi_cxx
+	 ${FC} ${FFLAGS} unit_test.f90 -o unit_test_fortran_wrapper -L. libMUI_Fortran_wrapper.a -lstdc++ -lmpi_cxx
+	 ${FC} ${FFLAGS} mui_f_wrapper_1d.f90 mui_f_wrapper_2d.f90 mui_f_wrapper_3d.f90 unit_test_multi.f90 -o unit_test_multi_fortran_wrapper -L. libMUI_Fortran_wrapper.a -lstdc++ -lmpi_cxx
 	 @echo "Launching unit test code for direct interface creation..."
 	 ${MPI} -np 1 ./unit_test_fortran_wrapper domain1 interface : -np 1 ./unit_test_fortran_wrapper domain2 interface
 	 @echo "Launching unit test code for interface creation using helper fucntion..."

--- a/wrappers/Fortran/mui_f_wrapper_1d.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_1d.cpp
@@ -193,6 +193,24 @@ typedef mui::temporal_sampler_sum1dx mui_temporal_sampler_sum_1dx;
 // Summation temporal sampler typedefs for template creation (recommended)
 typedef mui::temporal_sampler_sum<mui::mui_f_wrapper_1D> mui_temporal_sampler_sum_1t;
 
+// Fixed relaxation algorithm typedefs for specialism creation
+typedef mui::algo_fixed_relaxation1f mui_algorithm_fixed_relaxation_1f;
+typedef mui::algo_fixed_relaxation1fx mui_algorithm_fixed_relaxation_1fx;
+typedef mui::algo_fixed_relaxation1d mui_algorithm_fixed_relaxation_1d;
+typedef mui::algo_fixed_relaxation1dx mui_algorithm_fixed_relaxation_1dx;
+
+// Fixed relaxation algorithm typedefs for template creation (recommended)
+typedef mui::algo_fixed_relaxation<mui::mui_f_wrapper_1D> mui_algorithm_fixed_relaxation_1t;
+
+// Aitken's algorithm typedefs for specialism creation
+typedef mui::algo_aitken1f mui_algorithm_aitken_1f;
+typedef mui::algo_aitken1fx mui_algorithm_aitken_1fx;
+typedef mui::algo_aitken1d mui_algorithm_aitken_1d;
+typedef mui::algo_aitken1dx mui_algorithm_aitken_1dx;
+
+// Aitken's algorithm typedefs for template creation (recommended)
+typedef mui::algo_aitken<mui::mui_f_wrapper_1D> mui_algorithm_aitken_1t;
+
 // MUI set of specialism interface on multi-domain coupling
 mui_uniface_1f** mui_uniface_multi_1f;
 mui_uniface_1fx** mui_uniface_multi_1fx;
@@ -1137,6 +1155,325 @@ void mui_destroy_temporal_sampler_sum_1dx_f(mui_temporal_sampler_sum_1dx* sample
 
 void mui_destroy_temporal_sampler_sum_1t_f(mui_temporal_sampler_sum_1t* sampler) {
     delete sampler;
+}
+
+/*******************************************
+ * Create algorithms                       *
+ *******************************************/
+
+// Fixed relaxation algorithm
+void mui_create_algorithm_fixed_relaxation_1f_f(mui_algorithm_fixed_relaxation_1f **ret, float* under_relaxation_factor, float* points_1, float* value_init, int* pair_count) {
+
+	std::vector<std::pair<mui::point1f, float>> pts_value_init;
+
+	if ((*pair_count == 0) || (points_1 == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1f, float>>();
+	} else {
+		pts_value_init.resize(*pair_count);
+		for (size_t i = 0; i < *pair_count; i++) {
+			mui::point1f pts;
+			pts[0] = points_1[i];
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+    *ret = new mui_algorithm_fixed_relaxation_1f(*under_relaxation_factor, pts_value_init);
+}
+
+void mui_create_algorithm_fixed_relaxation_1fx_f(mui_algorithm_fixed_relaxation_1fx **ret, float* under_relaxation_factor, float* points_1, float* value_init, int* pair_count) {
+
+	std::vector<std::pair<mui::point1fx, float>> pts_value_init;
+
+	if ((*pair_count == 0) || (points_1 == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1fx, float>>();
+	} else {
+		pts_value_init.resize(*pair_count);
+		for (size_t i = 0; i < *pair_count; i++) {
+			mui::point1fx pts;
+			pts[0] = points_1[i];
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+    *ret = new mui_algorithm_fixed_relaxation_1fx(*under_relaxation_factor, pts_value_init);
+}
+
+void mui_create_algorithm_fixed_relaxation_1d_f(mui_algorithm_fixed_relaxation_1d **ret, double* under_relaxation_factor, double* points_1, double* value_init, int* pair_count) {
+
+	std::vector<std::pair<mui::point1d, double>> pts_value_init;
+
+	if ((*pair_count == 0) || (points_1 == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1d, double>>();
+	} else {
+		pts_value_init.resize(*pair_count);
+		for (size_t i = 0; i < *pair_count; i++) {
+			mui::point1d pts;
+			pts[0] = points_1[i];
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+    *ret = new mui_algorithm_fixed_relaxation_1d(*under_relaxation_factor, pts_value_init);
+}
+
+void mui_create_algorithm_fixed_relaxation_1dx_f(mui_algorithm_fixed_relaxation_1dx** ret, double* under_relaxation_factor, double* points_1, double* value_init, int* pair_count) {
+
+	std::vector<std::pair<mui::point1dx, double>> pts_value_init;
+
+	if ((*pair_count == 0) || (points_1 == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1dx, double>>();
+	} else {
+		pts_value_init.resize(*pair_count);
+		for (size_t i = 0; i < *pair_count; i++) {
+			mui::point1dx pts;
+			pts[0] = points_1[i];
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+    *ret = new mui_algorithm_fixed_relaxation_1dx(*under_relaxation_factor, pts_value_init);
+}
+
+void mui_create_algorithm_fixed_relaxation_1t_f(mui_algorithm_fixed_relaxation_1t** ret, double* under_relaxation_factor, double* points_1, double* value_init, int* pair_count) {
+
+	std::vector<std::pair<mui::mui_f_wrapper_1D::point_type, mui::mui_f_wrapper_1D::REAL>> pts_value_init;
+
+	if ((*pair_count == 0) || (points_1 == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::mui_f_wrapper_1D::point_type, mui::mui_f_wrapper_1D::REAL>>();
+	} else {
+		pts_value_init.resize(*pair_count);
+		for (size_t i = 0; i < *pair_count; i++) {
+			mui::mui_f_wrapper_1D::point_type pts;
+			pts[0] = points_1[i];
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+    *ret = new mui_algorithm_fixed_relaxation_1t(static_cast<mui::mui_f_wrapper_1D::REAL>(*under_relaxation_factor), pts_value_init);
+}
+
+// Aitken's algorithm
+void mui_create_algorithm_aitken_1f_f(mui_algorithm_aitken_1f **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Comm* communicator, float* points_1, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
+
+	std::vector<std::pair<mui::point1f, float>> pts_value_init;
+
+	if ((*pair_count == 0) || (points_1 == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1f, float>>();
+	} else {
+		pts_value_init.resize(*pair_count);
+		for (size_t i = 0; i < *pair_count; i++) {
+			mui::point1f pts;
+			pts[0] = points_1[i];
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+    *ret = new mui_algorithm_aitken_1f(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+}
+
+void mui_create_algorithm_aitken_1fx_f(mui_algorithm_aitken_1fx **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Comm* communicator, float* points_1, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
+
+	std::vector<std::pair<mui::point1fx, float>> pts_value_init;
+
+	if ((*pair_count == 0) || (points_1 == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1fx, float>>();
+	} else {
+		pts_value_init.resize(*pair_count);
+		for (size_t i = 0; i < *pair_count; i++) {
+			mui::point1fx pts;
+			pts[0] = points_1[i];
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+    *ret = new mui_algorithm_aitken_1fx(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+}
+
+void mui_create_algorithm_aitken_1d_f(mui_algorithm_aitken_1d **ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+
+	std::vector<std::pair<mui::point1d, double>> pts_value_init;
+
+	if ((*pair_count == 0) || (points_1 == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1d, double>>();
+	} else {
+		pts_value_init.resize(*pair_count);
+		for (size_t i = 0; i < *pair_count; i++) {
+			mui::point1d pts;
+			pts[0] = points_1[i];
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+    *ret = new mui_algorithm_aitken_1d(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+}
+
+void mui_create_algorithm_aitken_1dx_f(mui_algorithm_aitken_1dx** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+
+	std::vector<std::pair<mui::point1dx, double>> pts_value_init;
+
+	if ((*pair_count == 0) || (points_1 == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::point1dx, double>>();
+	} else {
+		pts_value_init.resize(*pair_count);
+		for (size_t i = 0; i < *pair_count; i++) {
+			mui::point1dx pts;
+			pts[0] = points_1[i];
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+    *ret = new mui_algorithm_aitken_1dx(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+}
+
+void mui_create_algorithm_aitken_1t_f(mui_algorithm_aitken_1t** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+
+	std::vector<std::pair<mui::mui_f_wrapper_1D::point_type, mui::mui_f_wrapper_1D::REAL>> pts_value_init;
+
+	if ((*pair_count == 0) || (points_1 == nullptr) || (value_init == nullptr)) {
+		pts_value_init = std::vector<std::pair<mui::mui_f_wrapper_1D::point_type, mui::mui_f_wrapper_1D::REAL>>();
+	} else {
+		pts_value_init.resize(*pair_count);
+		for (size_t i = 0; i < *pair_count; i++) {
+			mui::mui_f_wrapper_1D::point_type pts;
+			pts[0] = points_1[i];
+			pts_value_init[i] = std::make_pair(pts,value_init[i]);
+		}
+	}
+
+    *ret = new mui_algorithm_aitken_1t(static_cast<mui::mui_f_wrapper_1D::REAL>(*under_relaxation_factor), static_cast<mui::mui_f_wrapper_1D::REAL>(*under_relaxation_factor_max), reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, static_cast<mui::mui_f_wrapper_1D::REAL>(*res_l2_norm_nm1));
+}
+
+/*******************************************
+ * Aitken's functions for get info         *
+ *******************************************/
+
+// Aitken's get under relaxation factor functions
+void mui_aitken_get_under_relaxation_factor_1f_f(mui_algorithm_aitken_1f *aitken, float* t, float *return_value) {
+	*return_value = aitken->get_under_relaxation_factor(*t);
+}
+
+
+void mui_aitken_get_under_relaxation_factor_1fx_f(mui_algorithm_aitken_1fx *aitken, float* t, float *return_value) {
+	*return_value = aitken->get_under_relaxation_factor(*t);
+}
+
+void mui_aitken_get_under_relaxation_factor_1d_f(mui_algorithm_aitken_1d *aitken, double* t, double *return_value) {
+	*return_value = aitken->get_under_relaxation_factor(*t);
+}
+
+void mui_aitken_get_under_relaxation_factor_1dx_f(mui_algorithm_aitken_1dx *aitken, double* t, double *return_value) {
+	*return_value = aitken->get_under_relaxation_factor(*t);
+}
+
+void mui_aitken_get_under_relaxation_factor_1t_f(mui_algorithm_aitken_1t *aitken, double* t, double *return_value) {
+	*return_value = aitken->get_under_relaxation_factor(static_cast<mui::mui_f_wrapper_1D::time_type>(*t));
+}
+
+void mui_aitken_get_under_relaxation_factor_1f_pair_f(mui_algorithm_aitken_1f *aitken, float* t, float* it, float *return_value) {
+	*return_value = aitken->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_aitken_get_under_relaxation_factor_1fx_pair_f(mui_algorithm_aitken_1fx *aitken, float* t, float* it, float *return_value) {
+	*return_value = aitken->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_aitken_get_under_relaxation_factor_1d_pair_f(mui_algorithm_aitken_1d *aitken, double* t, double* it, double *return_value) {
+	*return_value = aitken->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_aitken_get_under_relaxation_factor_1dx_pair_f(mui_algorithm_aitken_1dx *aitken, double* t, double* it, double *return_value) {
+	*return_value = aitken->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_aitken_get_under_relaxation_factor_1t_pair_f(mui_algorithm_aitken_1t *aitken, double* t, double* it, double *return_value) {
+	*return_value = aitken->get_under_relaxation_factor(static_cast<mui::mui_f_wrapper_1D::time_type>(*t),
+			static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it));
+}
+
+// Aitken's get residual L2 Norm functions
+void mui_aitken_get_residual_L2_Norm_1f_f(mui_algorithm_aitken_1f *aitken, float* t, float *return_value) {
+	*return_value = aitken->get_residual_L2_Norm(*t);
+}
+
+void mui_aitken_get_residual_L2_Norm_1fx_f(mui_algorithm_aitken_1fx *aitken, float* t, float *return_value) {
+	*return_value = aitken->get_residual_L2_Norm(*t);
+}
+
+void mui_aitken_get_residual_L2_Norm_1d_f(mui_algorithm_aitken_1d *aitken, double* t, double *return_value) {
+	*return_value = aitken->get_residual_L2_Norm(*t);
+}
+
+void mui_aitken_get_residual_L2_Norm_1dx_f(mui_algorithm_aitken_1dx *aitken, double* t, double *return_value) {
+	*return_value = aitken->get_residual_L2_Norm(*t);
+}
+
+void mui_aitken_get_residual_L2_Norm_1t_f(mui_algorithm_aitken_1t *aitken, double* t, double *return_value) {
+	*return_value = aitken->get_residual_L2_Norm(static_cast<mui::mui_f_wrapper_1D::time_type>(*t));
+}
+
+void mui_aitken_get_residual_L2_Norm_1f_pair_f(mui_algorithm_aitken_1f *aitken, float* t, float* it, float *return_value) {
+	*return_value = aitken->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_aitken_get_residual_L2_Norm_1fx_pair_f(mui_algorithm_aitken_1fx *aitken, float* t, float* it, float *return_value) {
+	*return_value = aitken->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_aitken_get_residual_L2_Norm_1d_pair_f(mui_algorithm_aitken_1d *aitken, double* t, double* it, double *return_value) {
+	*return_value = aitken->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_aitken_get_residual_L2_Norm_1dx_pair_f(mui_algorithm_aitken_1dx *aitken, double* t, double* it, double *return_value) {
+	*return_value = aitken->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_aitken_get_residual_L2_Norm_1t_pair_f(mui_algorithm_aitken_1t *aitken, double* t, double* it, double *return_value) {
+	*return_value = aitken->get_residual_L2_Norm(static_cast<mui::mui_f_wrapper_1D::time_type>(*t),
+			static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it));
+}
+
+/*******************************************
+ * Destroy algorithms                      *
+ *******************************************/
+
+void mui_destroy_algorithm_fixed_relaxation_1f_f(mui_algorithm_fixed_relaxation_1f *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_fixed_relaxation_1fx_f(mui_algorithm_fixed_relaxation_1fx *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_fixed_relaxation_1d_f(mui_algorithm_fixed_relaxation_1d *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_fixed_relaxation_1dx_f(mui_algorithm_fixed_relaxation_1dx *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_fixed_relaxation_1t_f(mui_algorithm_fixed_relaxation_1t *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_aitken_1f_f(mui_algorithm_aitken_1f *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_aitken_1fx_f(mui_algorithm_aitken_1fx *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_aitken_1d_f(mui_algorithm_aitken_1d *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_aitken_1dx_f(mui_algorithm_aitken_1dx *algorithm) {
+	delete algorithm;
+}
+
+void mui_destroy_algorithm_aitken_1t_f(mui_algorithm_aitken_1t *algorithm) {
+	delete algorithm;
 }
 
 /******************************************
@@ -3481,6 +3818,4434 @@ void mui_fetch_rbf_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, doub
             static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
             *spatial_sampler, *temporal_sampler));
 }
+
+
+/************************************************************************
+ * MUI functions for 1D data fetch with algorithms using one time value *
+ ************************************************************************/
+
+// Spatial sampler: exact; temporal sampler: exact; algorithm: fixed relaxation
+void mui_fetch_exact_exact_fixed_relaxation_1f_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1f *algorithm, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_fixed_relaxation_1fx_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1fx *algorithm, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_fixed_relaxation_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1d *algorithm, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_fixed_relaxation_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1dx *algorithm, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_fixed_relaxation_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1t *algorithm, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler, *algorithm));
+
+}
+
+/*
+
+// Spatial sampler: exact; temporal sampler: gauss
+void mui_fetch_exact_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: exact; temporal sampler: mean
+void mui_fetch_exact_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: exact; temporal sampler: sum
+void mui_fetch_exact_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: gauss; temporal sampler: exact
+void mui_fetch_gauss_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: gauss; temporal sampler: gauss
+void mui_fetch_gauss_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: gauss; temporal sampler: mean
+void mui_fetch_gauss_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: gauss; temporal sampler: sum
+void mui_fetch_gauss_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: moving average; temporal sampler: exact
+void mui_fetch_moving_average_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: moving average; temporal sampler: gauss
+void mui_fetch_moving_average_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: moving average; temporal sampler: mean
+void mui_fetch_moving_average_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: moving average; temporal sampler: sum
+void mui_fetch_moving_average_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+void mui_fetch_nearest_neighbor_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+void mui_fetch_nearest_neighbor_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+void mui_fetch_nearest_neighbor_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+void mui_fetch_nearest_neighbor_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: pseudo nearest neighbor; temporal sampler: exact
+void mui_fetch_pseudo_nearest_neighbor_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1,
+        float* t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1dx(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+void mui_fetch_pseudo_nearest_neighbor_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1,
+        float* t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+void mui_fetch_pseudo_nearest_neighbor_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1,
+        float* t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+void mui_fetch_pseudo_nearest_neighbor_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1fx(mui_uniface_1fx *uniface, const char *attr, float *point_1,
+        float* t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: exact
+void mui_fetch_shepard_quintic_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: gauss
+void mui_fetch_shepard_quintic_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: mean
+void mui_fetch_shepard_quintic_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: sum
+void mui_fetch_shepard_quintic_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: exact
+void mui_fetch_sph_quintic_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: gauss
+void mui_fetch_sph_quintic_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: mean
+void mui_fetch_sph_quintic_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: sum
+void mui_fetch_sph_quintic_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: summation quintic; temporal sampler: exact
+void mui_fetch_sum_quintic_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: summation quintic; temporal sampler: gauss
+void mui_fetch_sum_quintic_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: summation quintic; temporal sampler: mean
+void mui_fetch_sum_quintic_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: summation quintic; temporal sampler: sum
+void mui_fetch_sum_quintic_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: radial basis function; temporal sampler: exact
+void mui_fetch_rbf_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: radial basis function; temporal sampler: gauss
+void mui_fetch_rbf_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: radial basis function; temporal sampler: mean
+void mui_fetch_rbf_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: radial basis function; temporal sampler: sum
+void mui_fetch_rbf_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+*/
+
+// Spatial sampler: exact; temporal sampler: exact; algorithm: aitken
+void mui_fetch_exact_exact_aitken_1f_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_aitken_1f *algorithm, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_aitken_1fx_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_aitken_1fx *algorithm, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_aitken_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_aitken_1d *algorithm, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_aitken_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_aitken_1dx *algorithm, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_aitken_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_aitken_1t *algorithm, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler, *algorithm));
+}
+
+/*
+
+// Spatial sampler: exact; temporal sampler: gauss
+void mui_fetch_exact_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: exact; temporal sampler: mean
+void mui_fetch_exact_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: exact; temporal sampler: sum
+void mui_fetch_exact_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: gauss; temporal sampler: exact
+void mui_fetch_gauss_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: gauss; temporal sampler: gauss
+void mui_fetch_gauss_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: gauss; temporal sampler: mean
+void mui_fetch_gauss_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: gauss; temporal sampler: sum
+void mui_fetch_gauss_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: moving average; temporal sampler: exact
+void mui_fetch_moving_average_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: moving average; temporal sampler: gauss
+void mui_fetch_moving_average_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: moving average; temporal sampler: mean
+void mui_fetch_moving_average_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: moving average; temporal sampler: sum
+void mui_fetch_moving_average_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+void mui_fetch_nearest_neighbor_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+void mui_fetch_nearest_neighbor_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+void mui_fetch_nearest_neighbor_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+void mui_fetch_nearest_neighbor_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_nearest_neighbor_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: pseudo nearest neighbor; temporal sampler: exact
+void mui_fetch_pseudo_nearest_neighbor_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1,
+        float* t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1dx(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+void mui_fetch_pseudo_nearest_neighbor_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1,
+        float* t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+void mui_fetch_pseudo_nearest_neighbor_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1,
+        float* t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+void mui_fetch_pseudo_nearest_neighbor_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1fx(mui_uniface_1fx *uniface, const char *attr, float *point_1,
+        float* t, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: exact
+void mui_fetch_shepard_quintic_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: gauss
+void mui_fetch_shepard_quintic_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: mean
+void mui_fetch_shepard_quintic_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: sum
+void mui_fetch_shepard_quintic_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: exact
+void mui_fetch_sph_quintic_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: gauss
+void mui_fetch_sph_quintic_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: mean
+void mui_fetch_sph_quintic_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: sum
+void mui_fetch_sph_quintic_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: summation quintic; temporal sampler: exact
+void mui_fetch_sum_quintic_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: summation quintic; temporal sampler: gauss
+void mui_fetch_sum_quintic_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: summation quintic; temporal sampler: mean
+void mui_fetch_sum_quintic_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: summation quintic; temporal sampler: sum
+void mui_fetch_sum_quintic_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: radial basis function; temporal sampler: exact
+void mui_fetch_rbf_exact_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: radial basis function; temporal sampler: gauss
+void mui_fetch_rbf_gauss_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: radial basis function; temporal sampler: mean
+void mui_fetch_rbf_mean_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: radial basis function; temporal sampler: sum
+void mui_fetch_rbf_sum_1f_f(mui_uniface_1f *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1fx_f(mui_uniface_1fx *uniface, const char *attr, float *point_1, float* t,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1d_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1dx_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1t_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+*/
+
+/*************************************************************************
+ * MUI functions for 1D data fetch with algorithms using two time values *
+ *************************************************************************/
+
+// Spatial sampler: exact; temporal sampler: exact; algorithm: fixed relaxation
+void mui_fetch_exact_exact_fixed_relaxation_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1f *algorithm, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_fixed_relaxation_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1fx *algorithm, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_fixed_relaxation_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1d *algorithm, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_fixed_relaxation_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1dx *algorithm, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_fixed_relaxation_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_fixed_relaxation_1t *algorithm, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler, *algorithm));
+}
+
+/*
+
+// Spatial sampler: exact; temporal sampler: gauss
+void mui_fetch_exact_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: exact; temporal sampler: mean
+void mui_fetch_exact_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: exact; temporal sampler: sum
+void mui_fetch_exact_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: gauss; temporal sampler: exact
+void mui_fetch_gauss_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: gauss; temporal sampler: gauss
+void mui_fetch_gauss_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: gauss; temporal sampler: mean
+void mui_fetch_gauss_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: moving average; temporal sampler: exact
+void mui_fetch_moving_average_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_moving_average_1fx *spatial_sampler,
+        mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_moving_average_1dx *spatial_sampler,
+        mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: moving average; temporal sampler: gauss
+void mui_fetch_moving_average_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_moving_average_1fx *spatial_sampler,
+        mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_moving_average_1dx *spatial_sampler,
+        mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: moving average; temporal sampler: mean
+void mui_fetch_moving_average_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_moving_average_1dx *spatial_sampler,
+        mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: moving average; temporal sampler: sum
+void mui_fetch_moving_average_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_moving_average_1dx *spatial_sampler,
+        mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+void mui_fetch_nearest_neighbor_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+void mui_fetch_nearest_neighbor_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+void mui_fetch_nearest_neighbor_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+void mui_fetch_nearest_neighbor_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+void mui_fetch_pseudo_nearest_neighbor_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+        mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+void mui_fetch_pseudo_nearest_neighbor_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+        mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+void mui_fetch_pseudo_nearest_neighbor_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+        mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+void mui_fetch_pseudo_nearest_neighbor_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+        mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: exact
+void mui_fetch_shepard_quintic_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+        mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1d *spatial_sampler,
+        mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+        mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1t *spatial_sampler,
+        mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: gauss
+void mui_fetch_shepard_quintic_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+        mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1d *spatial_sampler,
+        mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+        mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1t *spatial_sampler,
+        mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: mean
+void mui_fetch_shepard_quintic_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+        mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+        mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: sum
+void mui_fetch_shepard_quintic_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+        mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: exact
+void mui_fetch_sph_quintic_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: gauss
+void mui_fetch_sph_quintic_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: mean
+void mui_fetch_sph_quintic_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: sum
+void mui_fetch_sph_quintic_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: summation quintic; temporal sampler: exact
+void mui_fetch_sum_quintic_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: summation quintic; temporal sampler: gauss
+void mui_fetch_sum_quintic_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: summation quintic; temporal sampler: mean
+void mui_fetch_sum_quintic_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: summation quintic; temporal sampler: sum
+void mui_fetch_sum_quintic_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: radial basis function; temporal sampler: exact
+void mui_fetch_rbf_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: radial basis function; temporal sampler: gauss
+void mui_fetch_rbf_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: radial basis function; temporal sampler: mean
+void mui_fetch_rbf_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t, double* it,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t, double* it,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: radial basis function; temporal sampler: sum
+void mui_fetch_rbf_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t, double* it,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t, double* it,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+*/
+
+// Spatial sampler: exact; temporal sampler: exact; algorithm: aitken
+void mui_fetch_exact_exact_aitken_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler,
+		mui_algorithm_aitken_1f *algorithm, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_aitken_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler,
+		mui_algorithm_aitken_1fx *algorithm, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_aitken_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler,
+		mui_algorithm_aitken_1d *algorithm, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_aitken_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler,
+		mui_algorithm_aitken_1dx *algorithm, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler, *algorithm);
+}
+
+void mui_fetch_exact_exact_aitken_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler,
+		mui_algorithm_aitken_1t *algorithm, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler, *algorithm));
+}
+
+/*
+
+// Spatial sampler: exact; temporal sampler: gauss
+void mui_fetch_exact_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: exact; temporal sampler: mean
+void mui_fetch_exact_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: exact; temporal sampler: sum
+void mui_fetch_exact_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_exact_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_exact_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_exact_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_exact_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: gauss; temporal sampler: exact
+void mui_fetch_gauss_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: gauss; temporal sampler: gauss
+void mui_fetch_gauss_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: gauss; temporal sampler: mean
+void mui_fetch_gauss_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_gauss_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_gauss_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_gauss_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_gauss_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: moving average; temporal sampler: exact
+void mui_fetch_moving_average_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_moving_average_1fx *spatial_sampler,
+        mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_moving_average_1dx *spatial_sampler,
+        mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: moving average; temporal sampler: gauss
+void mui_fetch_moving_average_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_moving_average_1fx *spatial_sampler,
+        mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_moving_average_1dx *spatial_sampler,
+        mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: moving average; temporal sampler: mean
+void mui_fetch_moving_average_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_moving_average_1dx *spatial_sampler,
+        mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: moving average; temporal sampler: sum
+void mui_fetch_moving_average_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_moving_average_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_moving_average_1dx *spatial_sampler,
+        mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_moving_average_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_moving_average_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+void mui_fetch_nearest_neighbor_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+void mui_fetch_nearest_neighbor_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+void mui_fetch_nearest_neighbor_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+void mui_fetch_nearest_neighbor_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_nearest_neighbor_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_nearest_neighbor_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_nearest_neighbor_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_nearest_neighbor_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: exact
+void mui_fetch_pseudo_nearest_neighbor_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+        mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: gauss
+void mui_fetch_pseudo_nearest_neighbor_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+        mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: mean
+void mui_fetch_pseudo_nearest_neighbor_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+        mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: nearest neighbor; temporal sampler: sum
+void mui_fetch_pseudo_nearest_neighbor_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1f *spatial_sampler,
+        mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_pseudo_nearest_neighbor_1fx *spatial_sampler,
+        mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1d *spatial_sampler,
+        mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1dx *spatial_sampler,
+        mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_nearest_neighbor_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_pseudo_nearest_neighbor_1t *spatial_sampler,
+        mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: exact
+void mui_fetch_shepard_quintic_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+        mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1d *spatial_sampler,
+        mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+        mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1t *spatial_sampler,
+        mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: gauss
+void mui_fetch_shepard_quintic_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+        mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1d *spatial_sampler,
+        mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+        mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1t *spatial_sampler,
+        mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: mean
+void mui_fetch_shepard_quintic_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1,
+        float* t, float* it, mui_sampler_shepard_quintic_1fx *spatial_sampler,
+        mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+        mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: shepard quintic; temporal sampler: sum
+void mui_fetch_shepard_quintic_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_shepard_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_shepard_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_shepard_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1,
+        double* t, double* it, mui_sampler_shepard_quintic_1dx *spatial_sampler,
+        mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_shepard_quintic_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_shepard_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: exact
+void mui_fetch_sph_quintic_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: gauss
+void mui_fetch_sph_quintic_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: mean
+void mui_fetch_sph_quintic_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: sph-derived quintic; temporal sampler: sum
+void mui_fetch_sph_quintic_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sph_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sph_quintic_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sph_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: summation quintic; temporal sampler: exact
+void mui_fetch_sum_quintic_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: summation quintic; temporal sampler: gauss
+void mui_fetch_sum_quintic_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: summation quintic; temporal sampler: mean
+void mui_fetch_sum_quintic_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: summation quintic; temporal sampler: sum
+void mui_fetch_sum_quintic_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_sum_quintic_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_sum_quintic_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_sum_quintic_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: radial basis function; temporal sampler: exact
+void mui_fetch_rbf_exact_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_exact_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_exact_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_exact_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_exact_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_exact_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_exact_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: radial basis function; temporal sampler: gauss
+void mui_fetch_rbf_gauss_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_gauss_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t,
+        float* it, mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_gauss_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_gauss_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_gauss_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_gauss_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_gauss_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: radial basis function; temporal sampler: mean
+void mui_fetch_rbf_mean_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_mean_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_mean_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t, double* it,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_mean_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_mean_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_mean_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t, double* it,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_mean_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: radial basis function; temporal sampler: sum
+void mui_fetch_rbf_sum_1f_pair_f(mui_uniface_1f *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1f *spatial_sampler, mui_temporal_sampler_sum_1f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1f(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1fx_pair_f(mui_uniface_1fx *uniface, const char *attr, float* point_1, float* t, float* it,
+        mui_sampler_rbf_1fx *spatial_sampler, mui_temporal_sampler_sum_1fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1fx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1d_pair_f(mui_uniface_1d *uniface, const char *attr, double* point_1, double* t, double* it,
+        mui_sampler_rbf_1d *spatial_sampler, mui_temporal_sampler_sum_1d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1d(*point_1), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1dx_pair_f(mui_uniface_1dx *uniface, const char *attr, double* point_1, double* t,
+        double* it, mui_sampler_rbf_1dx *spatial_sampler, mui_temporal_sampler_sum_1dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point1dx(*point_1), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_rbf_sum_1t_pair_f(mui_uniface_1t *uniface, const char *attr, double* point_1, double* t, double* it,
+        mui_sampler_rbf_1t *spatial_sampler, mui_temporal_sampler_sum_1t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_1D::point_type point_fetch(static_cast<mui::mui_f_wrapper_1D::REAL>(*point_1));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_1D::time_type>(*t), static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+*/
 
 /*******************************************************************
  * MUI functions for 1D data point only fetch using one time value  *

--- a/wrappers/Fortran/mui_f_wrapper_1d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_1d.f90
@@ -104,9 +104,10 @@ module mui_1d_f
     end subroutine mui_create_uniface_1t_f
 
     !Set of 1D interfaces with float=single and int=int32
-    !Recomend to use the create_and_get_uniface_multi_1f_f(*) subroutine instead of use
-    ! this subroutine directly
-    subroutine mui_create_uniface_multi_1f_f(domain, interfaces, interface_count) bind(C)
+    !Recomend to use the create_and_get_uniface_multi_1f_f(*) subroutine
+    ! instead of use this subroutine directly
+    subroutine mui_create_uniface_multi_1f_f(domain, interfaces, &
+        interface_count) bind(C)
       import :: c_char,c_int
       character(kind=c_char), intent(in) :: domain(*)
       character(kind=c_char,len=*), intent(in) :: interfaces(*)
@@ -114,9 +115,10 @@ module mui_1d_f
     end subroutine mui_create_uniface_multi_1f_f
 
     !Set of 1D interfaces with float=single and int=int64
-    !Recomend to use the create_and_get_uniface_multi_1fx_f(*) subroutine instead of use
-    ! this subroutine directly
-    subroutine mui_create_uniface_multi_1fx_f(domain, interfaces, interface_count) bind(C)
+    !Recomend to use the create_and_get_uniface_multi_1fx_f(*) subroutine
+    ! instead of use this subroutine directly
+    subroutine mui_create_uniface_multi_1fx_f(domain, interfaces, &
+        interface_count) bind(C)
       import :: c_char,c_int
       character(kind=c_char), intent(in) :: domain(*)
       character(kind=c_char,len=*), intent(in) :: interfaces(*)
@@ -124,9 +126,10 @@ module mui_1d_f
     end subroutine mui_create_uniface_multi_1fx_f
 
     !Set of 1D interfaces with float=double and int=int32
-    !Recomend to use the create_and_get_uniface_multi_1d_f(*) subroutine instead of use
-    ! this subroutine directly
-    subroutine mui_create_uniface_multi_1d_f(domain, interfaces, interface_count) bind(C)
+    !Recomend to use the create_and_get_uniface_multi_1d_f(*) subroutine
+    ! instead of use this subroutine directly
+    subroutine mui_create_uniface_multi_1d_f(domain, interfaces, &
+        interface_count) bind(C)
       import :: c_char,c_int
       character(kind=c_char), intent(in) :: domain(*)
       character(kind=c_char,len=*), intent(in) :: interfaces(*)
@@ -134,9 +137,10 @@ module mui_1d_f
     end subroutine mui_create_uniface_multi_1d_f
 
     !Set of 1D interfaces with float=double and int=int64
-    !Recomend to use the create_and_get_uniface_multi_1dx_f(*) subroutine instead of use
-    ! this subroutine directly
-    subroutine mui_create_uniface_multi_1dx_f(domain, interfaces, interface_count) bind(C)
+    !Recomend to use the create_and_get_uniface_multi_1dx_f(*) subroutine
+    ! instead of use this subroutine directly
+    subroutine mui_create_uniface_multi_1dx_f(domain, interfaces, &
+        interface_count) bind(C)
       import :: c_char,c_int
       character(kind=c_char), intent(in) :: domain(*)
       character(kind=c_char,len=*), intent(in) :: interfaces(*)
@@ -144,9 +148,10 @@ module mui_1d_f
     end subroutine mui_create_uniface_multi_1dx_f
 
     !Set of 1D interfaces using config from config_c_wrapper.h
-    !Recomend to use the create_and_get_uniface_multi_1t_f(*) subroutine instead of use
-    ! this subroutine directly
-    subroutine mui_create_uniface_multi_1t_f(domain, interfaces, interface_count) bind(C)
+    !Recomend to use the create_and_get_uniface_multi_1t_f(*) subroutine
+    ! instead of use this subroutine directly
+    subroutine mui_create_uniface_multi_1t_f(domain, interfaces, &
+        interface_count) bind(C)
       import :: c_char,c_int
       character(kind=c_char), intent(in) :: domain(*)
       character(kind=c_char,len=*), intent(in) :: interfaces(*)
@@ -154,40 +159,40 @@ module mui_1d_f
     end subroutine mui_create_uniface_multi_1t_f
 
     !Access to MUI set of 1D interfaces with float=single and int=int32
-    !Recomend to use the create_and_get_uniface_multi_1f_f(*) subroutine instead of use
-    ! this subroutine directly
+    !Recomend to use the create_and_get_uniface_multi_1f_f(*) subroutine
+    ! instead of use this subroutine directly
     type(c_ptr) function get_mui_uniface_multi_1f_f(interface_count) bind(C)
       import :: c_ptr,c_int
       integer(kind=c_int), value :: interface_count
     end function get_mui_uniface_multi_1f_f
 
     !Access to MUI set of 1D interfaces with float=single and int=int64
-    !Recomend to use the create_and_get_uniface_multi_1fx_f(*) subroutine instead of use
-    ! this subroutine directly
+    !Recomend to use the create_and_get_uniface_multi_1fx_f(*) subroutine
+    ! instead of use this subroutine directly
     type(c_ptr) function get_mui_uniface_multi_1fx_f(interface_count) bind(C)
       import :: c_ptr,c_int
       integer(kind=c_int), value :: interface_count
     end function get_mui_uniface_multi_1fx_f
 
     !Access to MUI set of 1D interfaces with float=double and int=int32
-    !Recomend to use the create_and_get_uniface_multi_1d_f(*) subroutine instead of use
-    ! this subroutine directly
+    !Recomend to use the create_and_get_uniface_multi_1d_f(*) subroutine
+    ! instead of use this subroutine directly
     type(c_ptr) function get_mui_uniface_multi_1d_f(interface_count) bind(C)
       import :: c_ptr,c_int
       integer(kind=c_int), value :: interface_count
     end function get_mui_uniface_multi_1d_f
 
     !Access to MUI set of 1D interfaces with float=double and int=int64
-    !Recomend to use the create_and_get_uniface_multi_1dx_f(*) subroutine instead of use
-    ! this subroutine directly
+    !Recomend to use the create_and_get_uniface_multi_1dx_f(*) subroutine
+    ! instead of use this subroutine directly
     type(c_ptr) function get_mui_uniface_multi_1dx_f(interface_count) bind(C)
       import :: c_ptr,c_int
       integer(kind=c_int), value :: interface_count
     end function get_mui_uniface_multi_1dx_f
 
     !Access to MUI set of 1D interfaces using config from config_f_wrapper.h
-    !Recomend to use the create_and_get_uniface_multi_1t_f(*) subroutine instead of use
-    ! this subroutine directly
+    !Recomend to use the create_and_get_uniface_multi_1t_f(*) subroutine
+    ! instead of use this subroutine directly
     type(c_ptr) function get_mui_uniface_multi_1t_f(interface_count) bind(C)
       import :: c_ptr,c_int
       integer(kind=c_int), value :: interface_count
@@ -377,31 +382,36 @@ module mui_1d_f
     end subroutine mui_create_sampler_pseudo_n2_linear_1t_f
 
     !Pseudo-linear nearest neighbour interpolation sampler
-    subroutine mui_create_sampler_pseudo_nearest_neighbor_1f_f(sampler,h) bind(C)
+    subroutine mui_create_sampler_pseudo_nearest_neighbor_1f_f(sampler,h) &
+        bind(C)
       import :: c_ptr,c_float
       type(c_ptr), intent(out), target :: sampler(*)
       real(kind=c_float), intent(in), target :: h
     end subroutine mui_create_sampler_pseudo_nearest_neighbor_1f_f
 
-    subroutine mui_create_sampler_pseudo_nearest_neighbor_1fx_f(sampler,h) bind(C)
+    subroutine mui_create_sampler_pseudo_nearest_neighbor_1fx_f(sampler,h) &
+        bind(C)
       import :: c_ptr,c_float
       type(c_ptr), intent(out), target :: sampler(*)
       real(kind=c_float), intent(in), target :: h
     end subroutine mui_create_sampler_pseudo_nearest_neighbor_1fx_f
 
-    subroutine mui_create_sampler_pseudo_nearest_neighbor_1d_f(sampler,h) bind(C)
+    subroutine mui_create_sampler_pseudo_nearest_neighbor_1d_f(sampler,h) &
+        bind(C)
       import :: c_ptr,c_double
       type(c_ptr), intent(out), target :: sampler(*)
       real(kind=c_double), intent(in), target :: h
     end subroutine mui_create_sampler_pseudo_nearest_neighbor_1d_f
 
-    subroutine mui_create_sampler_pseudo_nearest_neighbor_1dx_f(sampler,h) bind(C)
+    subroutine mui_create_sampler_pseudo_nearest_neighbor_1dx_f(sampler,h) &
+        bind(C)
       import :: c_ptr,c_double
       type(c_ptr), intent(out), target :: sampler(*)
       real(kind=c_double), intent(in), target :: h
     end subroutine mui_create_sampler_pseudo_nearest_neighbor_1dx_f
 
-    subroutine mui_create_sampler_pseudo_nearest_neighbor_1t_f(sampler,h) bind(C)
+    subroutine mui_create_sampler_pseudo_nearest_neighbor_1t_f(sampler,h) &
+        bind(C)
       import :: c_ptr,c_double
       type(c_ptr), intent(out), target :: sampler(*)
       real(kind=c_double), intent(in), target :: h
@@ -501,57 +511,62 @@ module mui_1d_f
     end subroutine mui_create_sampler_sum_quintic_1t_f
 
     !Radial Basis Function sampler
-    subroutine mui_create_sampler_rbf_1f_f(sampler,r,points_1,points_count,basis_func,conservative,smoothFunc,readMatrix, &
-               writeMatrix,file_address,cutoff,cgSolveTol,cgSolveIt,pouSize) bind(C)
+    subroutine mui_create_sampler_rbf_1f_f(sampler,r,points_1,points_count, &
+                basis_func,conservative,smoothFunc,readMatrix, writeMatrix, &
+               file_address,cutoff,cgSolveTol,cgSolveIt,pouSize) bind(C)
       import :: c_ptr,c_int,c_float,c_char
       type(c_ptr), intent(out), target :: sampler(*)
       character(c_char), intent(in) :: file_address(*)
-      integer(kind=c_int), intent(in), target :: points_count,basis_func,conservative,smoothFunc,readMatrix,writeMatrix,cgSolveIt, &
-      pouSize
+      integer(kind=c_int), intent(in), target :: points_count,basis_func, &
+            conservative,smoothFunc,readMatrix,writeMatrix,cgSolveIt,pouSize
       real(kind=c_float), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_float), intent(in), dimension(points_count), target :: points_1
     end subroutine mui_create_sampler_rbf_1f_f
 
-    subroutine mui_create_sampler_rbf_1fx_f(sampler,r,points_1,points_count,basis_func,conservative,smoothFunc,readMatrix, &
-               writeMatrix,file_address,cutoff,cgSolveTol,cgSolveIt,pouSize) bind(C)
+    subroutine mui_create_sampler_rbf_1fx_f(sampler,r,points_1,points_count, &
+                basis_func,conservative,smoothFunc,readMatrix, writeMatrix, &
+               file_address,cutoff,cgSolveTol,cgSolveIt,pouSize) bind(C)
       import :: c_ptr,c_int,c_float,c_char
       type(c_ptr), intent(out), target :: sampler(*)
       character(kind=c_char), intent(in) :: file_address(*)
-      integer(kind=c_int), intent(in), target :: points_count,basis_func,conservative,smoothFunc,readMatrix,writeMatrix,cgSolveIt, &
-      pouSize
+      integer(kind=c_int), intent(in), target :: points_count,basis_func, &
+            conservative,smoothFunc,readMatrix,writeMatrix,cgSolveIt,pouSize
       real(kind=c_float), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_float), intent(in), dimension(points_count), target :: points_1
     end subroutine mui_create_sampler_rbf_1fx_f
 
-    subroutine mui_create_sampler_rbf_1d_f(sampler,r,points_1,points_count,basis_func,conservative,smoothFunc,readMatrix, &
-               writeMatrix,file_address,cutoff,cgSolveTol,cgSolveIt,pouSize) bind(C)
+    subroutine mui_create_sampler_rbf_1d_f(sampler,r,points_1,points_count, &
+                basis_func,conservative,smoothFunc,readMatrix,writeMatrix,  &
+               file_address,cutoff,cgSolveTol,cgSolveIt,pouSize) bind(C)
       import :: c_ptr,c_int,c_double,c_char
       type(c_ptr), intent(out), target :: sampler(*)
       character(kind=c_char), intent(in) :: file_address(*)
-      integer(kind=c_int), intent(in), target :: points_count,basis_func,conservative,smoothFunc,readMatrix,writeMatrix,cgSolveIt, &
-      pouSize
+      integer(kind=c_int), intent(in), target :: points_count,basis_func, &
+            conservative,smoothFunc,readMatrix,writeMatrix,cgSolveIt,pouSize
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_double), intent(in), dimension(points_count), target :: points_1
     end subroutine mui_create_sampler_rbf_1d_f
 
-    subroutine mui_create_sampler_rbf_1dx_f(sampler,r,points_1,points_count,basis_func,conservative,smoothFunc,readMatrix, &
-               writeMatrix,file_address,cutoff,cgSolveTol,cgSolveIt,pouSize) bind(C)
+    subroutine mui_create_sampler_rbf_1dx_f(sampler,r,points_1,points_count, &
+                basis_func,conservative,smoothFunc,readMatrix, writeMatrix,  &
+               file_address,cutoff,cgSolveTol,cgSolveIt,pouSize) bind(C)
       import :: c_ptr,c_int,c_double,c_char
       type(c_ptr), intent(out), target :: sampler(*)
       character(kind=c_char), intent(in) :: file_address(*)
-      integer(kind=c_int), intent(in), target :: points_count,basis_func,conservative,smoothFunc,readMatrix,writeMatrix,cgSolveIt, &
-      pouSize
+      integer(kind=c_int), intent(in), target :: points_count,basis_func, &
+            conservative,smoothFunc,readMatrix,writeMatrix,cgSolveIt,pouSize
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_double), intent(in), dimension(points_count), target :: points_1
     end subroutine mui_create_sampler_rbf_1dx_f
 
-    subroutine mui_create_sampler_rbf_1t_f(sampler,r,points_1,points_count,basis_func,conservative,smoothFunc,readMatrix, &
-               writeMatrix,file_address,cutoff,cgSolveTol,cgSolveIt,pouSize) bind(C)
+    subroutine mui_create_sampler_rbf_1t_f(sampler,r,points_1,points_count, &
+                basis_func,conservative,smoothFunc,readMatrix, writeMatrix,&
+               file_address,cutoff,cgSolveTol,cgSolveIt,pouSize) bind(C)
       import :: c_ptr,c_int,c_double,c_char
       type(c_ptr), intent(out), target :: sampler(*)
       character(kind=c_char), intent(in) :: file_address(*)
-      integer(kind=c_int), intent(in), target :: points_count,basis_func,conservative,smoothFunc,readMatrix,writeMatrix,cgSolveIt, &
-      pouSize
+      integer(kind=c_int), intent(in), target :: points_count,basis_func, &
+         conservative,smoothFunc,readMatrix,writeMatrix,cgSolveIt,pouSize
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(c_double), intent(in), dimension(points_count), target :: points_1
     end subroutine mui_create_sampler_rbf_1t_f
@@ -1055,6 +1070,347 @@ module mui_1d_f
       import :: c_ptr
       type(c_ptr), intent(in), value :: sampler
     end subroutine mui_destroy_temporal_sampler_sum_1t_f
+
+    !******************************************
+    !* Create algorithms                      *
+    !******************************************
+
+    !Fixed relaxation algorithm
+    subroutine mui_create_algorithm_fixed_relaxation_1f_f(algorithm, &
+        under_relaxation_factor,points_1,value_init,pair_count) bind(C)
+      import :: c_ptr,c_float,c_int
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_float),intent(in) :: under_relaxation_factor
+      integer(kind=c_int), intent(in), target :: pair_count
+      real(c_float), intent(in), dimension(pair_count), target :: points_1
+      real(c_float), intent(in), dimension(pair_count), target :: value_init
+    end subroutine mui_create_algorithm_fixed_relaxation_1f_f
+
+    subroutine mui_create_algorithm_fixed_relaxation_1fx_f(algorithm, &
+        under_relaxation_factor,points_1,value_init,pair_count) bind(C)
+      import :: c_ptr,c_float,c_int
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_float),intent(in) :: under_relaxation_factor
+      integer(kind=c_int), intent(in), target :: pair_count
+      real(c_float), intent(in), dimension(pair_count), target :: points_1
+      real(c_float), intent(in), dimension(pair_count), target :: value_init
+    end subroutine mui_create_algorithm_fixed_relaxation_1fx_f
+
+    subroutine mui_create_algorithm_fixed_relaxation_1d_f(algorithm, &
+        under_relaxation_factor,points_1,value_init,pair_count) bind(C)
+      import :: c_ptr,c_double,c_int
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double),intent(in) :: under_relaxation_factor
+      integer(kind=c_int), intent(in), target :: pair_count
+      real(c_double), intent(in), dimension(pair_count), target :: points_1
+      real(c_double), intent(in), dimension(pair_count), target :: value_init
+    end subroutine mui_create_algorithm_fixed_relaxation_1d_f
+
+    subroutine mui_create_algorithm_fixed_relaxation_1dx_f(algorithm, &
+        under_relaxation_factor,points_1,value_init,pair_count) bind(C)
+      import :: c_ptr,c_double,c_int
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double),intent(in) :: under_relaxation_factor
+      integer(kind=c_int), intent(in), target :: pair_count
+      real(c_double), intent(in), dimension(pair_count), target :: points_1
+      real(c_double), intent(in), dimension(pair_count), target :: value_init
+    end subroutine mui_create_algorithm_fixed_relaxation_1dx_f
+
+    subroutine mui_create_algorithm_fixed_relaxation_1t_f(algorithm, &
+        under_relaxation_factor,points_1,value_init,pair_count) bind(C)
+      import :: c_ptr,c_double,c_int
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double),intent(in) :: under_relaxation_factor
+      integer(kind=c_int), intent(in), target :: pair_count
+      real(c_double), intent(in), dimension(pair_count), target :: points_1
+      real(c_double), intent(in), dimension(pair_count), target :: value_init
+    end subroutine mui_create_algorithm_fixed_relaxation_1t_f
+
+    !Aitken's algorithm
+    subroutine mui_create_algorithm_aitken_1f_f(algorithm, &
+        under_relaxation_factor,under_relaxation_factor_max, &
+        communicator,points_1,value_init,pair_count,res_l2_norm_nm1) bind(C)
+      import :: c_ptr,c_float,c_int
+      type(c_ptr), intent(out), target :: algorithm(*)
+      type(c_ptr), intent(in), target :: communicator(*)
+      real(kind=c_float),intent(in) :: under_relaxation_factor, &
+        under_relaxation_factor_max,res_l2_norm_nm1
+      integer(kind=c_int), intent(in), target :: pair_count
+      real(c_float), intent(in), dimension(pair_count), target :: points_1
+      real(c_float), intent(in), dimension(pair_count), target :: value_init
+    end subroutine mui_create_algorithm_aitken_1f_f
+
+    subroutine mui_create_algorithm_aitken_1fx_f(algorithm,               &
+        under_relaxation_factor,under_relaxation_factor_max,communicator, &
+        points_1,value_init,pair_count,res_l2_norm_nm1) bind(C)
+      import :: c_ptr,c_float,c_int
+      type(c_ptr), intent(out), target :: algorithm(*)
+      type(c_ptr), intent(in), target :: communicator(*)
+      real(kind=c_float),intent(in) :: under_relaxation_factor, &
+        under_relaxation_factor_max,res_l2_norm_nm1
+      integer(kind=c_int), intent(in), target :: pair_count
+      real(c_float), intent(in), dimension(pair_count), target :: points_1
+      real(c_float), intent(in), dimension(pair_count), target :: value_init
+    end subroutine mui_create_algorithm_aitken_1fx_f
+
+    subroutine mui_create_algorithm_aitken_1d_f(algorithm,                &
+        under_relaxation_factor,under_relaxation_factor_max,communicator, &
+        points_1,value_init,pair_count,res_l2_norm_nm1) bind(C)
+      import :: c_ptr,c_double,c_int
+      type(c_ptr), intent(out), target :: algorithm(*)
+      type(c_ptr), intent(in), target :: communicator(*)
+      real(kind=c_double),intent(in) :: under_relaxation_factor, &
+        under_relaxation_factor_max,res_l2_norm_nm1
+      integer(kind=c_int), intent(in), target :: pair_count
+      real(c_double), intent(in), dimension(pair_count), target :: points_1
+      real(c_double), intent(in), dimension(pair_count), target :: value_init
+    end subroutine mui_create_algorithm_aitken_1d_f
+
+    subroutine mui_create_algorithm_aitken_1dx_f(algorithm, &
+        under_relaxation_factor,under_relaxation_factor_max,communicator, &
+        points_1,value_init,pair_count,res_l2_norm_nm1) bind(C)
+      import :: c_ptr,c_double,c_int
+      type(c_ptr), intent(out), target :: algorithm(*)
+      type(c_ptr), intent(in), target :: communicator(*)
+      real(kind=c_double),intent(in) :: under_relaxation_factor, &
+        under_relaxation_factor_max,res_l2_norm_nm1
+      integer(kind=c_int), intent(in), target :: pair_count
+      real(c_double), intent(in), dimension(pair_count), target :: points_1
+      real(c_double), intent(in), dimension(pair_count), target :: value_init
+    end subroutine mui_create_algorithm_aitken_1dx_f
+
+    subroutine mui_create_algorithm_aitken_1t_f(algorithm, &
+        under_relaxation_factor,under_relaxation_factor_max,communicator, &
+        points_1,value_init,pair_count,res_l2_norm_nm1) bind(C)
+      import :: c_ptr,c_double,c_int
+      type(c_ptr), intent(out), target :: algorithm(*)
+      type(c_ptr), intent(in), target :: communicator(*)
+      real(kind=c_double),intent(in) :: under_relaxation_factor, &
+        under_relaxation_factor_max,res_l2_norm_nm1
+      integer(kind=c_int), intent(in), target :: pair_count
+      real(c_double), intent(in), dimension(pair_count), target :: points_1
+      real(c_double), intent(in), dimension(pair_count), target :: value_init
+    end subroutine mui_create_algorithm_aitken_1t_f
+
+    !******************************************
+    !* Aitken's functions for get info        *
+    !******************************************
+
+    !Aitken's get under relaxation factor functions
+    subroutine mui_aitken_get_under_relaxation_factor_1f_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_aitken_get_under_relaxation_factor_1f_f
+
+    subroutine mui_aitken_get_under_relaxation_factor_1fx_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_aitken_get_under_relaxation_factor_1fx_f
+
+    subroutine mui_aitken_get_under_relaxation_factor_1d_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_under_relaxation_factor_1d_f
+
+    subroutine mui_aitken_get_under_relaxation_factor_1dx_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_under_relaxation_factor_1dx_f
+
+    subroutine mui_aitken_get_under_relaxation_factor_1t_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_under_relaxation_factor_1t_f
+
+    subroutine mui_aitken_get_under_relaxation_factor_1f_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_aitken_get_under_relaxation_factor_1f_pair_f
+
+    subroutine mui_aitken_get_under_relaxation_factor_1fx_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_aitken_get_under_relaxation_factor_1fx_pair_f
+
+    subroutine mui_aitken_get_under_relaxation_factor_1d_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_under_relaxation_factor_1d_pair_f
+
+    subroutine mui_aitken_get_under_relaxation_factor_1dx_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_under_relaxation_factor_1dx_pair_f
+
+    subroutine mui_aitken_get_under_relaxation_factor_1t_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_under_relaxation_factor_1t_pair_f
+
+    !Aitken's get residual L2 Norm functions
+    subroutine mui_aitken_get_residual_L2_Norm_1f_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_aitken_get_residual_L2_Norm_1f_f
+
+    subroutine mui_aitken_get_residual_L2_Norm_1fx_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_aitken_get_residual_L2_Norm_1fx_f
+
+    subroutine mui_aitken_get_residual_L2_Norm_1d_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_residual_L2_Norm_1d_f
+
+    subroutine mui_aitken_get_residual_L2_Norm_1dx_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_residual_L2_Norm_1dx_f
+
+    subroutine mui_aitken_get_residual_L2_Norm_1t_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_residual_L2_Norm_1t_f
+
+    subroutine mui_aitken_get_residual_L2_Norm_1f_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_aitken_get_residual_L2_Norm_1f_pair_f
+
+    subroutine mui_aitken_get_residual_L2_Norm_1fx_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_aitken_get_residual_L2_Norm_1fx_pair_f
+
+    subroutine mui_aitken_get_residual_L2_Norm_1d_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_residual_L2_Norm_1d_pair_f
+
+    subroutine mui_aitken_get_residual_L2_Norm_1dx_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_residual_L2_Norm_1dx_pair_f
+
+    subroutine mui_aitken_get_residual_L2_Norm_1t_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(out), target :: algorithm(*)
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_aitken_get_residual_L2_Norm_1t_pair_f
+
+    !******************************************
+    !* Destroy algorithms                     *
+    !******************************************
+
+    subroutine mui_destroy_algorithm_fixed_relaxation_1f_f(algorithm) bind(C)
+      import :: c_ptr
+      type(c_ptr), intent(in), value :: algorithm
+    end subroutine mui_destroy_algorithm_fixed_relaxation_1f_f
+
+    subroutine mui_destroy_algorithm_fixed_relaxation_1fx_f(algorithm) bind(C)
+      import :: c_ptr
+      type(c_ptr), intent(in), value :: algorithm
+    end subroutine mui_destroy_algorithm_fixed_relaxation_1fx_f
+
+    subroutine mui_destroy_algorithm_fixed_relaxation_1d_f(algorithm) bind(C)
+      import :: c_ptr
+      type(c_ptr), intent(in), value :: algorithm
+    end subroutine mui_destroy_algorithm_fixed_relaxation_1d_f
+
+    subroutine mui_destroy_algorithm_fixed_relaxation_1dx_f(algorithm) bind(C)
+      import :: c_ptr
+      type(c_ptr), intent(in), value :: algorithm
+    end subroutine mui_destroy_algorithm_fixed_relaxation_1dx_f
+
+    subroutine mui_destroy_algorithm_fixed_relaxation_1t_f(algorithm) bind(C)
+      import :: c_ptr
+      type(c_ptr), intent(in), value :: algorithm
+    end subroutine mui_destroy_algorithm_fixed_relaxation_1t_f
+
+    subroutine mui_destroy_algorithm_aitken_1f_f(algorithm) bind(C)
+      import :: c_ptr
+      type(c_ptr), intent(in), value :: algorithm
+    end subroutine mui_destroy_algorithm_aitken_1f_f
+
+    subroutine mui_destroy_algorithm_aitken_1fx_f(algorithm) bind(C)
+      import :: c_ptr
+      type(c_ptr), intent(in), value :: algorithm
+    end subroutine mui_destroy_algorithm_aitken_1fx_f
+
+    subroutine mui_destroy_algorithm_aitken_1d_f(algorithm) bind(C)
+      import :: c_ptr
+      type(c_ptr), intent(in), value :: algorithm
+    end subroutine mui_destroy_algorithm_aitken_1d_f
+
+    subroutine mui_destroy_algorithm_aitken_1dx_f(algorithm) bind(C)
+      import :: c_ptr
+      type(c_ptr), intent(in), value :: algorithm
+    end subroutine mui_destroy_algorithm_aitken_1dx_f
+
+    subroutine mui_destroy_algorithm_aitken_1t_f(algorithm) bind(C)
+      import :: c_ptr
+      type(c_ptr), intent(in), value :: algorithm
+    end subroutine mui_destroy_algorithm_aitken_1t_f
 
     !******************************************
     !* MUI functions for data push            *
@@ -4424,6 +4780,6329 @@ module mui_1d_f
       real(kind=c_double), intent(out) :: return_value
     end subroutine mui_fetch_rbf_sum_1t_pair_f
 
+
+    !*************************************************************************
+    !* MUI functions for 1D data fetch with algorithms using one time value  *
+    !*************************************************************************
+
+    !Spatial sampler: exact; temporal sampler: exact; algorithm: fixed relaxation
+    subroutine mui_fetch_exact_exact_fixed_relaxation_1f_f(uniface,attr,point_1,t, &
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_fixed_relaxation_1f_f
+
+    subroutine mui_fetch_exact_exact_fixed_relaxation_1fx_f(uniface,attr,point_1,t, &
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_fixed_relaxation_1fx_f
+
+    subroutine mui_fetch_exact_exact_fixed_relaxation_1d_f(uniface,attr,point_1,t, &
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_fixed_relaxation_1d_f
+
+    subroutine mui_fetch_exact_exact_fixed_relaxation_1dx_f(uniface,attr,point_1,t, &
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_fixed_relaxation_1dx_f
+
+    subroutine mui_fetch_exact_exact_fixed_relaxation_1t_f(uniface,attr,point_1,t, &
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_fixed_relaxation_1t_f
+
+!    !Spatial sampler: exact; temporal sampler: gauss
+!    subroutine mui_fetch_exact_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1f_f
+!
+!    subroutine mui_fetch_exact_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1fx_f
+!
+!    subroutine mui_fetch_exact_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1d_f
+!
+!    subroutine mui_fetch_exact_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1dx_f
+!
+!    subroutine mui_fetch_exact_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1t_f
+!
+!    !Spatial sampler: exact; temporal sampler: mean
+!    subroutine mui_fetch_exact_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1f_f
+!
+!    subroutine mui_fetch_exact_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1fx_f
+!
+!    subroutine mui_fetch_exact_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1d_f
+!
+!    subroutine mui_fetch_exact_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1dx_f
+!
+!    subroutine mui_fetch_exact_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1t_f
+!
+!    !Spatial sampler: exact; temporal sampler: sum
+!    subroutine mui_fetch_exact_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1f_f
+!
+!    subroutine mui_fetch_exact_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1fx_f
+!
+!    subroutine mui_fetch_exact_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1d_f
+!
+!    subroutine mui_fetch_exact_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1dx_f
+!
+!    subroutine mui_fetch_exact_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1t_f
+!
+!    !Spatial sampler: gauss; temporal sampler: exact
+!    subroutine mui_fetch_gauss_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1f_f
+!
+!    subroutine mui_fetch_gauss_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1fx_f
+!
+!    subroutine mui_fetch_gauss_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1d_f
+!
+!    subroutine mui_fetch_gauss_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1dx_f
+!
+!    subroutine mui_fetch_gauss_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1t_f
+!
+!    !Spatial sampler: gauss; temporal sampler: gauss
+!    subroutine mui_fetch_gauss_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1f_f
+!
+!    subroutine mui_fetch_gauss_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1fx_f
+!
+!    subroutine mui_fetch_gauss_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1d_f
+!
+!    subroutine mui_fetch_gauss_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1dx_f
+!
+!    subroutine mui_fetch_gauss_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1t_f
+!
+!    !Spatial sampler: gauss; temporal sampler: mean
+!    subroutine mui_fetch_gauss_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1f_f
+!
+!    subroutine mui_fetch_gauss_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1fx_f
+!
+!    subroutine mui_fetch_gauss_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1d_f
+!
+!    subroutine mui_fetch_gauss_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1dx_f
+!
+!    subroutine mui_fetch_gauss_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1t_f
+!
+!    !Spatial sampler: gauss; temporal sampler: sum
+!    subroutine mui_fetch_gauss_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1f_f
+!
+!    subroutine mui_fetch_gauss_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1fx_f
+!
+!    subroutine mui_fetch_gauss_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1d_f
+!
+!    subroutine mui_fetch_gauss_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1dx_f
+!
+!    subroutine mui_fetch_gauss_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1t_f
+!
+!    !Spatial sampler: moving average; temporal sampler: exact
+!    subroutine mui_fetch_moving_average_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1f_f
+!
+!    subroutine mui_fetch_moving_average_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1fx_f
+!
+!    subroutine mui_fetch_moving_average_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1d_f
+!
+!    subroutine mui_fetch_moving_average_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1dx_f
+!
+!    subroutine mui_fetch_moving_average_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1t_f
+!
+!    !Spatial sampler: moving average; temporal sampler: gauss
+!    subroutine mui_fetch_moving_average_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1f_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1fx_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1d_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1dx_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1t_f
+!
+!    !Spatial sampler: moving average; temporal sampler: mean
+!    subroutine mui_fetch_moving_average_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1f_f
+!
+!    subroutine mui_fetch_moving_average_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1fx_f
+!
+!    subroutine mui_fetch_moving_average_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1d_f
+!
+!    subroutine mui_fetch_moving_average_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1dx_f
+!
+!    subroutine mui_fetch_moving_average_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1t_f
+!
+!    !Spatial sampler: moving average; temporal sampler: sum
+!    subroutine mui_fetch_moving_average_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1f_f
+!
+!    subroutine mui_fetch_moving_average_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1fx_f
+!
+!    subroutine mui_fetch_moving_average_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1d_f
+!
+!    subroutine mui_fetch_moving_average_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1dx_f
+!
+!    subroutine mui_fetch_moving_average_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1t_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: exact
+!    subroutine mui_fetch_nearest_neighbor_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1f_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1fx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1d_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1dx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1t_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: gauss
+!    subroutine mui_fetch_nearest_neighbor_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1f_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1fx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1d_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1dx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1t_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: mean
+!    subroutine mui_fetch_nearest_neighbor_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1f_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1fx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1d_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1dx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1t_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: sum
+!    subroutine mui_fetch_nearest_neighbor_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1f_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1fx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1d_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1dx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1t_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: exact
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1f_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1f_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1fx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1fx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1d_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1d_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1dx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1dx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1t_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1t_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: gauss
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1f_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1f_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1fx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1fx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1d_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1d_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1dx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1dx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1t_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1t_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: mean
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1f_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1f_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1fx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1fx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1d_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1d_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1dx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1dx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1t_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1t_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: sum
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1f_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1f_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1fx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1fx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1d_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1d_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1dx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1dx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1t_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1t_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: exact
+!    subroutine mui_fetch_shepard_quintic_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1f_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1fx_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1d_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1dx_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1t_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: gauss
+!    subroutine mui_fetch_shepard_quintic_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1f_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1fx_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1d_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1dx_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1t_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: mean
+!    subroutine mui_fetch_shepard_quintic_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1f_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1fx_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1d_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1dx_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1t_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: sum
+!    subroutine mui_fetch_shepard_quintic_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1f_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1fx_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1d_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1dx_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1t_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: exact
+!    subroutine mui_fetch_sph_quintic_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1f_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1fx_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1d_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1dx_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1t_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: gauss
+!    subroutine mui_fetch_sph_quintic_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1f_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1fx_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1d_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1dx_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1t_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: mean
+!    subroutine mui_fetch_sph_quintic_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1f_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1fx_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1d_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1dx_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1t_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: sum
+!    subroutine mui_fetch_sph_quintic_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1f_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1fx_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1d_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1dx_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1t_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: exact
+!    subroutine mui_fetch_sum_quintic_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1f_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1fx_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1d_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1dx_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1t_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: gauss
+!    subroutine mui_fetch_sum_quintic_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1f_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1fx_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1d_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1dx_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1t_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: mean
+!    subroutine mui_fetch_sum_quintic_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1f_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1fx_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1d_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1dx_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1t_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: sum
+!    subroutine mui_fetch_sum_quintic_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1f_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1fx_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1d_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1dx_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1t_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: exact
+!    subroutine mui_fetch_rbf_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1f_f
+!
+!    subroutine mui_fetch_rbf_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1fx_f
+!
+!    subroutine mui_fetch_rbf_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1d_f
+!
+!    subroutine mui_fetch_rbf_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1dx_f
+!
+!    subroutine mui_fetch_rbf_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1t_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: gauss
+!    subroutine mui_fetch_rbf_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1f_f
+!
+!    subroutine mui_fetch_rbf_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1fx_f
+!
+!    subroutine mui_fetch_rbf_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1d_f
+!
+!    subroutine mui_fetch_rbf_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1dx_f
+!
+!    subroutine mui_fetch_rbf_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1t_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: mean
+!    subroutine mui_fetch_rbf_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1f_f
+!
+!    subroutine mui_fetch_rbf_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1fx_f
+!
+!    subroutine mui_fetch_rbf_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1d_f
+!
+!    subroutine mui_fetch_rbf_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1dx_f
+!
+!    subroutine mui_fetch_rbf_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1t_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: sum
+!    subroutine mui_fetch_rbf_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1f_f
+!
+!    subroutine mui_fetch_rbf_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1fx_f
+!
+!    subroutine mui_fetch_rbf_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1d_f
+!
+!    subroutine mui_fetch_rbf_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1dx_f
+!
+!    subroutine mui_fetch_rbf_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1t_f
+
+    !Spatial sampler: exact; temporal sampler: exact; algorithm: aitken
+    subroutine mui_fetch_exact_exact_aitken_1f_f(uniface,attr,point_1,t, &
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_aitken_1f_f
+
+    subroutine mui_fetch_exact_exact_aitken_1fx_f(uniface,attr,point_1,t, &
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_aitken_1fx_f
+
+    subroutine mui_fetch_exact_exact_aitken_1d_f(uniface,attr,point_1,t, &
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_aitken_1d_f
+
+    subroutine mui_fetch_exact_exact_aitken_1dx_f(uniface,attr,point_1,t, &
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_aitken_1dx_f
+
+    subroutine mui_fetch_exact_exact_aitken_1t_f(uniface,attr,point_1,t, &
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_aitken_1t_f
+
+!    !Spatial sampler: exact; temporal sampler: gauss
+!    subroutine mui_fetch_exact_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1f_f
+!
+!    subroutine mui_fetch_exact_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1fx_f
+!
+!    subroutine mui_fetch_exact_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1d_f
+!
+!    subroutine mui_fetch_exact_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1dx_f
+!
+!    subroutine mui_fetch_exact_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1t_f
+!
+!    !Spatial sampler: exact; temporal sampler: mean
+!    subroutine mui_fetch_exact_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1f_f
+!
+!    subroutine mui_fetch_exact_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1fx_f
+!
+!    subroutine mui_fetch_exact_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1d_f
+!
+!    subroutine mui_fetch_exact_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1dx_f
+!
+!    subroutine mui_fetch_exact_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1t_f
+!
+!    !Spatial sampler: exact; temporal sampler: sum
+!    subroutine mui_fetch_exact_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1f_f
+!
+!    subroutine mui_fetch_exact_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1fx_f
+!
+!    subroutine mui_fetch_exact_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1d_f
+!
+!    subroutine mui_fetch_exact_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1dx_f
+!
+!    subroutine mui_fetch_exact_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1t_f
+!
+!    !Spatial sampler: gauss; temporal sampler: exact
+!    subroutine mui_fetch_gauss_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1f_f
+!
+!    subroutine mui_fetch_gauss_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1fx_f
+!
+!    subroutine mui_fetch_gauss_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1d_f
+!
+!    subroutine mui_fetch_gauss_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1dx_f
+!
+!    subroutine mui_fetch_gauss_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1t_f
+!
+!    !Spatial sampler: gauss; temporal sampler: gauss
+!    subroutine mui_fetch_gauss_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1f_f
+!
+!    subroutine mui_fetch_gauss_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1fx_f
+!
+!    subroutine mui_fetch_gauss_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1d_f
+!
+!    subroutine mui_fetch_gauss_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1dx_f
+!
+!    subroutine mui_fetch_gauss_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1t_f
+!
+!    !Spatial sampler: gauss; temporal sampler: mean
+!    subroutine mui_fetch_gauss_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1f_f
+!
+!    subroutine mui_fetch_gauss_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1fx_f
+!
+!    subroutine mui_fetch_gauss_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1d_f
+!
+!    subroutine mui_fetch_gauss_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1dx_f
+!
+!    subroutine mui_fetch_gauss_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1t_f
+!
+!    !Spatial sampler: gauss; temporal sampler: sum
+!    subroutine mui_fetch_gauss_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1f_f
+!
+!    subroutine mui_fetch_gauss_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1fx_f
+!
+!    subroutine mui_fetch_gauss_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1d_f
+!
+!    subroutine mui_fetch_gauss_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1dx_f
+!
+!    subroutine mui_fetch_gauss_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1t_f
+!
+!    !Spatial sampler: moving average; temporal sampler: exact
+!    subroutine mui_fetch_moving_average_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1f_f
+!
+!    subroutine mui_fetch_moving_average_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1fx_f
+!
+!    subroutine mui_fetch_moving_average_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1d_f
+!
+!    subroutine mui_fetch_moving_average_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1dx_f
+!
+!    subroutine mui_fetch_moving_average_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1t_f
+!
+!    !Spatial sampler: moving average; temporal sampler: gauss
+!    subroutine mui_fetch_moving_average_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1f_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1fx_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1d_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1dx_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1t_f
+!
+!    !Spatial sampler: moving average; temporal sampler: mean
+!    subroutine mui_fetch_moving_average_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1f_f
+!
+!    subroutine mui_fetch_moving_average_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1fx_f
+!
+!    subroutine mui_fetch_moving_average_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1d_f
+!
+!    subroutine mui_fetch_moving_average_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1dx_f
+!
+!    subroutine mui_fetch_moving_average_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1t_f
+!
+!    !Spatial sampler: moving average; temporal sampler: sum
+!    subroutine mui_fetch_moving_average_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1f_f
+!
+!    subroutine mui_fetch_moving_average_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1fx_f
+!
+!    subroutine mui_fetch_moving_average_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1d_f
+!
+!    subroutine mui_fetch_moving_average_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1dx_f
+!
+!    subroutine mui_fetch_moving_average_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1t_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: exact
+!    subroutine mui_fetch_nearest_neighbor_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1f_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1fx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1d_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1dx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1t_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: gauss
+!    subroutine mui_fetch_nearest_neighbor_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1f_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1fx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1d_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1dx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1t_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: mean
+!    subroutine mui_fetch_nearest_neighbor_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1f_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1fx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1d_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1dx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1t_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: sum
+!    subroutine mui_fetch_nearest_neighbor_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1f_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1fx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1d_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1dx_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1t_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: exact
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1f_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1f_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1fx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1fx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1d_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1d_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1dx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1dx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1t_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1t_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: gauss
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1f_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1f_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1fx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1fx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1d_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1d_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1dx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1dx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1t_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1t_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: mean
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1f_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1f_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1fx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1fx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1d_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1d_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1dx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1dx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1t_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1t_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: sum
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1f_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1f_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1fx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1fx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1d_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1d_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1dx_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1dx_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1t_f(uniface,attr,point_1,t,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1t_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: exact
+!    subroutine mui_fetch_shepard_quintic_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1f_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1fx_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1d_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1dx_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1t_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: gauss
+!    subroutine mui_fetch_shepard_quintic_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1f_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1fx_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1d_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1dx_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1t_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: mean
+!    subroutine mui_fetch_shepard_quintic_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1f_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1fx_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1d_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1dx_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1t_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: sum
+!    subroutine mui_fetch_shepard_quintic_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1f_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1fx_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1d_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1dx_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1t_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: exact
+!    subroutine mui_fetch_sph_quintic_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1f_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1fx_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1d_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1dx_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1t_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: gauss
+!    subroutine mui_fetch_sph_quintic_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1f_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1fx_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1d_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1dx_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1t_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: mean
+!    subroutine mui_fetch_sph_quintic_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1f_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1fx_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1d_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1dx_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1t_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: sum
+!    subroutine mui_fetch_sph_quintic_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1f_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1fx_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1d_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1dx_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1t_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: exact
+!    subroutine mui_fetch_sum_quintic_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1f_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1fx_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1d_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1dx_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1t_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: gauss
+!    subroutine mui_fetch_sum_quintic_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1f_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1fx_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1d_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1dx_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1t_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: mean
+!    subroutine mui_fetch_sum_quintic_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1f_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1fx_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1d_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1dx_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1t_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: sum
+!    subroutine mui_fetch_sum_quintic_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1f_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1fx_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1d_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1dx_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1t_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: exact
+!    subroutine mui_fetch_rbf_exact_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1f_f
+!
+!    subroutine mui_fetch_rbf_exact_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1fx_f
+!
+!    subroutine mui_fetch_rbf_exact_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1d_f
+!
+!    subroutine mui_fetch_rbf_exact_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1dx_f
+!
+!    subroutine mui_fetch_rbf_exact_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1t_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: gauss
+!    subroutine mui_fetch_rbf_gauss_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1f_f
+!
+!    subroutine mui_fetch_rbf_gauss_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1fx_f
+!
+!    subroutine mui_fetch_rbf_gauss_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1d_f
+!
+!    subroutine mui_fetch_rbf_gauss_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1dx_f
+!
+!    subroutine mui_fetch_rbf_gauss_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1t_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: mean
+!    subroutine mui_fetch_rbf_mean_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1f_f
+!
+!    subroutine mui_fetch_rbf_mean_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1fx_f
+!
+!    subroutine mui_fetch_rbf_mean_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1d_f
+!
+!    subroutine mui_fetch_rbf_mean_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1dx_f
+!
+!    subroutine mui_fetch_rbf_mean_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1t_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: sum
+!    subroutine mui_fetch_rbf_sum_1f_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1f_f
+!
+!    subroutine mui_fetch_rbf_sum_1fx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1fx_f
+!
+!    subroutine mui_fetch_rbf_sum_1d_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1d_f
+!
+!    subroutine mui_fetch_rbf_sum_1dx_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1dx_f
+!
+!    subroutine mui_fetch_rbf_sum_1t_f(uniface,attr,point_1,t,spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1t_f
+
+    !*********************************************************
+    !* MUI functions for 1D data fetch using two time values *
+    !*********************************************************
+
+    !Spatial sampler: exact; temporal sampler: exact; algorithm: fixed relaxation
+    subroutine mui_fetch_exact_exact_fixed_relaxation_1f_pair_f(uniface,attr,point_1,t,it,&
+    spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_fixed_relaxation_1f_pair_f
+
+    subroutine mui_fetch_exact_exact_fixed_relaxation_1fx_pair_f(uniface,attr,point_1,t,it,&
+    spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_fixed_relaxation_1fx_pair_f
+
+    subroutine mui_fetch_exact_exact_fixed_relaxation_1d_pair_f(uniface,attr,point_1,t,it,&
+    spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_fixed_relaxation_1d_pair_f
+
+    subroutine mui_fetch_exact_exact_fixed_relaxation_1dx_pair_f(uniface,attr,point_1,t,it,&
+    spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_fixed_relaxation_1dx_pair_f
+
+    subroutine mui_fetch_exact_exact_fixed_relaxation_1t_pair_f(uniface,attr,point_1,t,it,&
+    spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_fixed_relaxation_1t_pair_f
+
+!    !Spatial sampler: exact; temporal sampler: gauss
+!    subroutine mui_fetch_exact_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_exact_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_exact_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_exact_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_exact_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1t_pair_f
+!
+!    !Spatial sampler: exact; temporal sampler: mean
+!    subroutine mui_fetch_exact_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1f_pair_f
+!
+!    subroutine mui_fetch_exact_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_exact_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1d_pair_f
+!
+!    subroutine mui_fetch_exact_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_exact_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1t_pair_f
+!
+!    !Spatial sampler: exact; temporal sampler: sum
+!    subroutine mui_fetch_exact_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1f_pair_f
+!
+!    subroutine mui_fetch_exact_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_exact_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1d_pair_f
+!
+!    subroutine mui_fetch_exact_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_exact_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1t_pair_f
+!
+!    !Spatial sampler: gauss; temporal sampler: exact
+!    subroutine mui_fetch_gauss_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1f_pair_f
+!
+!    subroutine mui_fetch_gauss_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_gauss_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1d_pair_f
+!
+!    subroutine mui_fetch_gauss_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_gauss_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1t_pair_f
+!
+!    !Spatial sampler: gauss; temporal sampler: gauss
+!    subroutine mui_fetch_gauss_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_gauss_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_gauss_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_gauss_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_gauss_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1t_pair_f
+!
+!    !Spatial sampler: gauss; temporal sampler: mean
+!    subroutine mui_fetch_gauss_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1f_pair_f
+!
+!    subroutine mui_fetch_gauss_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_gauss_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1d_pair_f
+!
+!    subroutine mui_fetch_gauss_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_gauss_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1t_pair_f
+!
+!    !Spatial sampler: gauss; temporal sampler: sum
+!    subroutine mui_fetch_gauss_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1f_pair_f
+!
+!    subroutine mui_fetch_gauss_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_gauss_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1d_pair_f
+!
+!    subroutine mui_fetch_gauss_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_gauss_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1t_pair_f
+!
+!    !Spatial sampler: moving average; temporal sampler: exact
+!    subroutine mui_fetch_moving_average_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1f_pair_f
+!
+!    subroutine mui_fetch_moving_average_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_moving_average_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1d_pair_f
+!
+!    subroutine mui_fetch_moving_average_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_moving_average_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1t_pair_f
+!
+!    !Spatial sampler: moving average; temporal sampler: gauss
+!    subroutine mui_fetch_moving_average_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1t_pair_f
+!
+!    !Spatial sampler: moving average; temporal sampler: mean
+!    subroutine mui_fetch_moving_average_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1f_pair_f
+!
+!    subroutine mui_fetch_moving_average_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_moving_average_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1d_pair_f
+!
+!    subroutine mui_fetch_moving_average_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_moving_average_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1t_pair_f
+!
+!    !Spatial sampler: moving average; temporal sampler: sum
+!    subroutine mui_fetch_moving_average_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1f_pair_f
+!
+!    subroutine mui_fetch_moving_average_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_moving_average_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1d_pair_f
+!
+!    subroutine mui_fetch_moving_average_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_moving_average_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1t_pair_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: exact
+!    subroutine mui_fetch_nearest_neighbor_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1f_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1d_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1t_pair_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: gauss
+!    subroutine mui_fetch_nearest_neighbor_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1t_pair_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: mean
+!    subroutine mui_fetch_nearest_neighbor_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1f_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1d_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1t_pair_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: sum
+!    subroutine mui_fetch_nearest_neighbor_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1f_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1d_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1t_pair_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: exact
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1f_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1d_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1t_pair_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: gauss
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1t_pair_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: mean
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1f_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1d_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1t_pair_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: sum
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1f_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1d_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1t_pair_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: exact
+!    subroutine mui_fetch_shepard_quintic_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1f_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1d_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1t_pair_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: gauss
+!    subroutine mui_fetch_shepard_quintic_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1t_pair_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: mean
+!    subroutine mui_fetch_shepard_quintic_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1f_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1d_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1t_pair_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: sum
+!    subroutine mui_fetch_shepard_quintic_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1f_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1d_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1t_pair_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: exact
+!    subroutine mui_fetch_sph_quintic_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1f_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1d_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1t_pair_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: gauss
+!    subroutine mui_fetch_sph_quintic_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1t_pair_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: mean
+!    subroutine mui_fetch_sph_quintic_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1f_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1d_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1t_pair_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: sum
+!    subroutine mui_fetch_sph_quintic_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1f_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1d_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1t_pair_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: exact
+!    subroutine mui_fetch_sum_quintic_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1f_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1d_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1t_pair_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: gauss
+!    subroutine mui_fetch_sum_quintic_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1t_pair_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: mean
+!    subroutine mui_fetch_sum_quintic_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1f_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1d_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1t_pair_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: sum
+!    subroutine mui_fetch_sum_quintic_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1f_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1d_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1t_pair_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: exact
+!    subroutine mui_fetch_rbf_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1f_pair_f
+!
+!    subroutine mui_fetch_rbf_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_rbf_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1d_pair_f
+!
+!    subroutine mui_fetch_rbf_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_rbf_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1t_pair_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: gauss
+!    subroutine mui_fetch_rbf_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_rbf_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_rbf_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_rbf_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_rbf_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1t_pair_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: mean
+!    subroutine mui_fetch_rbf_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1f_pair_f
+!
+!    subroutine mui_fetch_rbf_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_rbf_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1d_pair_f
+!
+!    subroutine mui_fetch_rbf_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_rbf_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1t_pair_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: sum
+!    subroutine mui_fetch_rbf_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1f_pair_f
+!
+!    subroutine mui_fetch_rbf_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_rbf_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1d_pair_f
+!
+!    subroutine mui_fetch_rbf_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_rbf_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1t_pair_f
+
+    !Spatial sampler: exact; temporal sampler: exact; algorithm: aitken
+    subroutine mui_fetch_exact_exact_aitken_1f_pair_f(uniface,attr,point_1,t,it,&
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_aitken_1f_pair_f
+
+    subroutine mui_fetch_exact_exact_aitken_1fx_pair_f(uniface,attr,point_1,t,it,&
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_aitken_1fx_pair_f
+
+    subroutine mui_fetch_exact_exact_aitken_1d_pair_f(uniface,attr,point_1,t,it,&
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_aitken_1d_pair_f
+
+    subroutine mui_fetch_exact_exact_aitken_1dx_pair_f(uniface,attr,point_1,t,it,&
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_aitken_1dx_pair_f
+
+    subroutine mui_fetch_exact_exact_aitken_1t_pair_f(uniface,attr,point_1,t,it,&
+        spatial_sampler,temporal_sampler,algorithm,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler,algorithm
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_exact_exact_aitken_1t_pair_f
+
+!    !Spatial sampler: exact; temporal sampler: gauss
+!    subroutine mui_fetch_exact_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_exact_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_exact_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_exact_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_exact_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_gauss_1t_pair_f
+!
+!    !Spatial sampler: exact; temporal sampler: mean
+!    subroutine mui_fetch_exact_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1f_pair_f
+!
+!    subroutine mui_fetch_exact_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_exact_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1d_pair_f
+!
+!    subroutine mui_fetch_exact_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_exact_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_mean_1t_pair_f
+!
+!    !Spatial sampler: exact; temporal sampler: sum
+!    subroutine mui_fetch_exact_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1f_pair_f
+!
+!    subroutine mui_fetch_exact_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_exact_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1d_pair_f
+!
+!    subroutine mui_fetch_exact_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_exact_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_exact_sum_1t_pair_f
+!
+!    !Spatial sampler: gauss; temporal sampler: exact
+!    subroutine mui_fetch_gauss_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1f_pair_f
+!
+!    subroutine mui_fetch_gauss_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_gauss_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1d_pair_f
+!
+!    subroutine mui_fetch_gauss_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_gauss_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_exact_1t_pair_f
+!
+!    !Spatial sampler: gauss; temporal sampler: gauss
+!    subroutine mui_fetch_gauss_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_gauss_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_gauss_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_gauss_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_gauss_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_gauss_1t_pair_f
+!
+!    !Spatial sampler: gauss; temporal sampler: mean
+!    subroutine mui_fetch_gauss_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1f_pair_f
+!
+!    subroutine mui_fetch_gauss_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_gauss_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1d_pair_f
+!
+!    subroutine mui_fetch_gauss_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_gauss_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_mean_1t_pair_f
+!
+!    !Spatial sampler: gauss; temporal sampler: sum
+!    subroutine mui_fetch_gauss_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1f_pair_f
+!
+!    subroutine mui_fetch_gauss_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_gauss_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1d_pair_f
+!
+!    subroutine mui_fetch_gauss_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_gauss_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_gauss_sum_1t_pair_f
+!
+!    !Spatial sampler: moving average; temporal sampler: exact
+!    subroutine mui_fetch_moving_average_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1f_pair_f
+!
+!    subroutine mui_fetch_moving_average_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_moving_average_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1d_pair_f
+!
+!    subroutine mui_fetch_moving_average_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_moving_average_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_exact_1t_pair_f
+!
+!    !Spatial sampler: moving average; temporal sampler: gauss
+!    subroutine mui_fetch_moving_average_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_moving_average_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_gauss_1t_pair_f
+!
+!    !Spatial sampler: moving average; temporal sampler: mean
+!    subroutine mui_fetch_moving_average_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1f_pair_f
+!
+!    subroutine mui_fetch_moving_average_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_moving_average_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1d_pair_f
+!
+!    subroutine mui_fetch_moving_average_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_moving_average_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_mean_1t_pair_f
+!
+!    !Spatial sampler: moving average; temporal sampler: sum
+!    subroutine mui_fetch_moving_average_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1f_pair_f
+!
+!    subroutine mui_fetch_moving_average_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_moving_average_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1d_pair_f
+!
+!    subroutine mui_fetch_moving_average_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_moving_average_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_moving_average_sum_1t_pair_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: exact
+!    subroutine mui_fetch_nearest_neighbor_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1f_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1d_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_exact_1t_pair_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: gauss
+!    subroutine mui_fetch_nearest_neighbor_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_gauss_1t_pair_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: mean
+!    subroutine mui_fetch_nearest_neighbor_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1f_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1d_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_mean_1t_pair_f
+!
+!    !Spatial sampler: nearest neighbor; temporal sampler: sum
+!    subroutine mui_fetch_nearest_neighbor_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1f_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1d_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_nearest_neighbor_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_nearest_neighbor_sum_1t_pair_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: exact
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1f_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1d_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_exact_1t_pair_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: gauss
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_gauss_1t_pair_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: mean
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1f_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1d_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_mean_1t_pair_f
+!
+!    !Spatial sampler: pseudo nearest neighbor; temporal sampler: sum
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1f_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1d_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_pseudo_nearest_neighbor_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_pseudo_nearest_neighbor_sum_1t_pair_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: exact
+!    subroutine mui_fetch_shepard_quintic_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1f_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1d_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_exact_1t_pair_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: gauss
+!    subroutine mui_fetch_shepard_quintic_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_gauss_1t_pair_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: mean
+!    subroutine mui_fetch_shepard_quintic_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1f_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1d_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_mean_1t_pair_f
+!
+!    !Spatial sampler: shepard quintic; temporal sampler: sum
+!    subroutine mui_fetch_shepard_quintic_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1f_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1d_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_shepard_quintic_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_shepard_quintic_sum_1t_pair_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: exact
+!    subroutine mui_fetch_sph_quintic_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1f_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1d_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_exact_1t_pair_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: gauss
+!    subroutine mui_fetch_sph_quintic_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_gauss_1t_pair_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: mean
+!    subroutine mui_fetch_sph_quintic_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1f_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1d_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_mean_1t_pair_f
+!
+!    !Spatial sampler: sph-derived quintic; temporal sampler: sum
+!    subroutine mui_fetch_sph_quintic_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1f_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1d_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_sph_quintic_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sph_quintic_sum_1t_pair_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: exact
+!    subroutine mui_fetch_sum_quintic_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1f_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1d_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_exact_1t_pair_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: gauss
+!    subroutine mui_fetch_sum_quintic_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_gauss_1t_pair_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: mean
+!    subroutine mui_fetch_sum_quintic_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1f_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1d_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_mean_1t_pair_f
+!
+!    !Spatial sampler: summation quintic; temporal sampler: sum
+!    subroutine mui_fetch_sum_quintic_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1f_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1d_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_sum_quintic_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_sum_quintic_sum_1t_pair_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: exact
+!    subroutine mui_fetch_rbf_exact_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1f_pair_f
+!
+!    subroutine mui_fetch_rbf_exact_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1fx_pair_f
+!
+!    subroutine mui_fetch_rbf_exact_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1d_pair_f
+!
+!    subroutine mui_fetch_rbf_exact_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1dx_pair_f
+!
+!    subroutine mui_fetch_rbf_exact_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_exact_1t_pair_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: gauss
+!    subroutine mui_fetch_rbf_gauss_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1f_pair_f
+!
+!    subroutine mui_fetch_rbf_gauss_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1fx_pair_f
+!
+!    subroutine mui_fetch_rbf_gauss_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1d_pair_f
+!
+!    subroutine mui_fetch_rbf_gauss_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1dx_pair_f
+!
+!    subroutine mui_fetch_rbf_gauss_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_gauss_1t_pair_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: mean
+!    subroutine mui_fetch_rbf_mean_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1f_pair_f
+!
+!    subroutine mui_fetch_rbf_mean_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1fx_pair_f
+!
+!    subroutine mui_fetch_rbf_mean_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1d_pair_f
+!
+!    subroutine mui_fetch_rbf_mean_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1dx_pair_f
+!
+!    subroutine mui_fetch_rbf_mean_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_mean_1t_pair_f
+!
+!    !Spatial sampler: radial basis function; temporal sampler: sum
+!    subroutine mui_fetch_rbf_sum_1f_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1f_pair_f
+!
+!    subroutine mui_fetch_rbf_sum_1fx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_float
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_float), intent(in) :: point_1,t,it
+!      real(kind=c_float), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1fx_pair_f
+!
+!    subroutine mui_fetch_rbf_sum_1d_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1d_pair_f
+!
+!    subroutine mui_fetch_rbf_sum_1dx_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1dx_pair_f
+!
+!    subroutine mui_fetch_rbf_sum_1t_pair_f(uniface,attr,point_1,t,it,&
+!    spatial_sampler,temporal_sampler,return_value) bind(C)
+!      import :: c_ptr,c_char,c_double
+!      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+!      character(kind=c_char), intent(in) :: attr(*)
+!      real(kind=c_double), intent(in) :: point_1,t,it
+!      real(kind=c_double), intent(out) :: return_value
+!    end subroutine mui_fetch_rbf_sum_1t_pair_f
+
     !*******************************************************************
     !* MUI functions for 1D data point only fetch using one time value *
     !*******************************************************************
@@ -5819,21 +12498,21 @@ module mui_1d_f
     end subroutine mui_set_forget_length_1fx_f
 
     subroutine mui_set_forget_length_1d_f(uniface,length) bind(C)
-      import :: c_ptr,c_float
+      import :: c_ptr,c_double
       type(c_ptr), intent(in), value :: uniface
-      real(kind=c_float), intent(in), value :: length
+      real(kind=c_double), intent(in), value :: length
     end subroutine mui_set_forget_length_1d_f
 
     subroutine mui_set_forget_length_1dx_f(uniface,length) bind(C)
-      import :: c_ptr,c_float
+      import :: c_ptr,c_double
       type(c_ptr), intent(in), value :: uniface
-      real(kind=c_float), intent(in), value :: length
+      real(kind=c_double), intent(in), value :: length
     end subroutine mui_set_forget_length_1dx_f
 
     subroutine mui_set_forget_length_1t_f(uniface,length) bind(C)
-      import :: c_ptr,c_float
+      import :: c_ptr,c_double
       type(c_ptr), intent(in), value :: uniface
-      real(kind=c_float), intent(in), value :: length
+      real(kind=c_double), intent(in), value :: length
     end subroutine mui_set_forget_length_1t_f
 
     !******************************************

--- a/wrappers/Fortran/mui_f_wrapper_2d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_2d.f90
@@ -5964,21 +5964,21 @@ module mui_2d_f
     end subroutine mui_set_forget_length_2fx_f
 
     subroutine mui_set_forget_length_2d_f(uniface,length) bind(C)
-      import :: c_ptr,c_float
+      import :: c_ptr,c_double
       type(c_ptr), intent(in), value :: uniface
-      real(kind=c_float), intent(in), value :: length
+      real(kind=c_double), intent(in), value :: length
     end subroutine mui_set_forget_length_2d_f
 
     subroutine mui_set_forget_length_2dx_f(uniface,length) bind(C)
-      import :: c_ptr,c_float
+      import :: c_ptr,c_double
       type(c_ptr), intent(in), value :: uniface
-      real(kind=c_float), intent(in), value :: length
+      real(kind=c_double), intent(in), value :: length
     end subroutine mui_set_forget_length_2dx_f
 
     subroutine mui_set_forget_length_2t_f(uniface,length) bind(C)
-      import :: c_ptr,c_float
+      import :: c_ptr,c_double
       type(c_ptr), intent(in), value :: uniface
-      real(kind=c_float), intent(in), value :: length
+      real(kind=c_double), intent(in), value :: length
     end subroutine mui_set_forget_length_2t_f
 
     !******************************************

--- a/wrappers/Fortran/mui_f_wrapper_3d.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_3d.cpp
@@ -1791,7 +1791,7 @@ void mui_fetch_pseudo_nearest_neighbor_exact_3t_f(mui_uniface_3t *uniface, const
 
 }
 
-// Spatial sampler: nearest neighbor; temporal sampler: gauss
+// Spatial sampler: pseudo nearest neighbor; temporal sampler: gauss
 void mui_fetch_pseudo_nearest_neighbor_gauss_3f_f(mui_uniface_3f *uniface, const char *attr, float *point_1, float *point_2, float *point_3, float* t,
         mui_sampler_pseudo_nearest_neighbor_3f *spatial_sampler, mui_temporal_sampler_gauss_3f *temporal_sampler, float *return_value) {
     *return_value = uniface->fetch(std::string(attr), mui::point3f(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
@@ -1824,7 +1824,7 @@ void mui_fetch_pseudo_nearest_neighbor_gauss_3t_f(mui_uniface_3t *uniface, const
 
 }
 
-// Spatial sampler: nearest neighbor; temporal sampler: mean
+// Spatial sampler: pseudo nearest neighbor; temporal sampler: mean
 void mui_fetch_pseudo_nearest_neighbor_mean_3f_f(mui_uniface_3f *uniface, const char *attr, float *point_1, float *point_2, float *point_3, float* t,
         mui_sampler_pseudo_nearest_neighbor_3f *spatial_sampler, mui_temporal_sampler_mean_3f *temporal_sampler, float *return_value) {
     *return_value = uniface->fetch(std::string(attr), mui::point3f(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
@@ -1857,7 +1857,7 @@ void mui_fetch_pseudo_nearest_neighbor_mean_3t_f(mui_uniface_3t *uniface, const 
 
 }
 
-// Spatial sampler: nearest neighbor; temporal sampler: sum
+// Spatial sampler: pseudo nearest neighbor; temporal sampler: sum
 void mui_fetch_pseudo_nearest_neighbor_sum_3f_f(mui_uniface_3f *uniface, const char *attr, float *point_1, float *point_2, float *point_3, float* t,
         mui_sampler_pseudo_nearest_neighbor_3f *spatial_sampler, mui_temporal_sampler_sum_3f *temporal_sampler, float *return_value) {
     *return_value = uniface->fetch(std::string(attr), mui::point3f(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
@@ -1882,6 +1882,137 @@ void mui_fetch_pseudo_nearest_neighbor_sum_3dx_f(mui_uniface_3dx *uniface, const
 
 void mui_fetch_pseudo_nearest_neighbor_sum_3t_f(mui_uniface_3t *uniface, const char *attr, double* point_1, double* point_2, double* point_3, double* t,
         mui_sampler_pseudo_nearest_neighbor_3t *spatial_sampler, mui_temporal_sampler_sum_3t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_3D::point_type point_fetch(static_cast<mui::mui_f_wrapper_3D::REAL>(*point_1,*point_2,*point_3));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_3D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+
+// Spatial sampler: pseudo nearest neighbor linear; temporal sampler: exact
+void mui_fetch_pseudo_n2_linear_exact_3f_f(mui_uniface_3f *uniface, const char *attr, float *point_1, float *point_2, float *point_3, float* t,
+        mui_sampler_pseudo_n2_linear_3f *spatial_sampler, mui_temporal_sampler_exact_3f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3f(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_exact_3fx_f(mui_uniface_3fx *uniface, const char *attr, float *point_1, float *point_2, float *point_3,
+        float* t, mui_sampler_pseudo_n2_linear_3fx *spatial_sampler,
+        mui_temporal_sampler_exact_3fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3fx(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_exact_3d_f(mui_uniface_3d *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, mui_sampler_pseudo_n2_linear_3d *spatial_sampler,
+        mui_temporal_sampler_exact_3d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3d(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_exact_3dx(mui_uniface_3dx *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, mui_sampler_pseudo_n2_linear_3dx *spatial_sampler,
+        mui_temporal_sampler_exact_3dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3dx(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_exact_3t_f(mui_uniface_3t *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, mui_sampler_pseudo_n2_linear_3t *spatial_sampler,
+        mui_temporal_sampler_exact_3t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_3D::point_type point_fetch(static_cast<mui::mui_f_wrapper_3D::REAL>(*point_1,*point_2,*point_3));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_3D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: pseudo nearest neighbor linear; temporal sampler: gauss
+void mui_fetch_pseudo_n2_linear_gauss_3f_f(mui_uniface_3f *uniface, const char *attr, float *point_1, float *point_2, float *point_3, float* t,
+        mui_sampler_pseudo_n2_linear_3f *spatial_sampler, mui_temporal_sampler_gauss_3f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3f(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_gauss_3fx_f(mui_uniface_3fx *uniface, const char *attr, float *point_1, float *point_2, float *point_3,
+        float* t, mui_sampler_pseudo_n2_linear_3fx *spatial_sampler,
+        mui_temporal_sampler_gauss_3fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3fx(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_gauss_3d_f(mui_uniface_3d *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, mui_sampler_pseudo_n2_linear_3d *spatial_sampler,
+        mui_temporal_sampler_gauss_3d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3d(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_gauss_3dx_f(mui_uniface_3dx *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, mui_sampler_pseudo_n2_linear_3dx *spatial_sampler,
+        mui_temporal_sampler_gauss_3dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3dx(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_gauss_3t_f(mui_uniface_3t *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, mui_sampler_pseudo_n2_linear_3t *spatial_sampler,
+        mui_temporal_sampler_gauss_3t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_3D::point_type point_fetch(static_cast<mui::mui_f_wrapper_3D::REAL>(*point_1,*point_2,*point_3));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_3D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: pseudo nearest neighbor linear; temporal sampler: mean
+void mui_fetch_pseudo_n2_linear_mean_3f_f(mui_uniface_3f *uniface, const char *attr, float *point_1, float *point_2, float *point_3, float* t,
+        mui_sampler_pseudo_n2_linear_3f *spatial_sampler, mui_temporal_sampler_mean_3f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3f(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_mean_3fx_f(mui_uniface_3fx *uniface, const char *attr, float *point_1, float *point_2, float *point_3,
+        float* t, mui_sampler_pseudo_n2_linear_3fx *spatial_sampler,
+        mui_temporal_sampler_mean_3fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3fx(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_mean_3d_f(mui_uniface_3d *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, mui_sampler_pseudo_n2_linear_3d *spatial_sampler,
+        mui_temporal_sampler_mean_3d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3d(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_mean_3dx_f(mui_uniface_3dx *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, mui_sampler_pseudo_n2_linear_3dx *spatial_sampler,
+        mui_temporal_sampler_mean_3dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3dx(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_mean_3t_f(mui_uniface_3t *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, mui_sampler_pseudo_n2_linear_3t *spatial_sampler,
+        mui_temporal_sampler_mean_3t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_3D::point_type point_fetch(static_cast<mui::mui_f_wrapper_3D::REAL>(*point_1,*point_2,*point_3));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_3D::time_type>(*t), *spatial_sampler, *temporal_sampler));
+
+}
+
+// Spatial sampler: pseudo nearest neighbor linear; temporal sampler: sum
+void mui_fetch_pseudo_n2_linear_sum_3f_f(mui_uniface_3f *uniface, const char *attr, float *point_1, float *point_2, float *point_3, float* t,
+        mui_sampler_pseudo_n2_linear_3f *spatial_sampler, mui_temporal_sampler_sum_3f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3f(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_sum_3fx(mui_uniface_3fx *uniface, const char *attr, float *point_1, float *point_2, float *point_3,
+        float* t, mui_sampler_pseudo_n2_linear_3fx *spatial_sampler,
+        mui_temporal_sampler_sum_3fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3fx(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_sum_3d_f(mui_uniface_3d *uniface, const char *attr, double* point_1, double* point_2, double* point_3, double* t,
+        mui_sampler_pseudo_n2_linear_3d *spatial_sampler, mui_temporal_sampler_sum_3d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3d(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_sum_3dx_f(mui_uniface_3dx *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, mui_sampler_pseudo_n2_linear_3dx *spatial_sampler,
+        mui_temporal_sampler_sum_3dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3dx(*point_1,*point_2,*point_3), *t, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_sum_3t_f(mui_uniface_3t *uniface, const char *attr, double* point_1, double* point_2, double* point_3, double* t,
+        mui_sampler_pseudo_n2_linear_3t *spatial_sampler, mui_temporal_sampler_sum_3t *temporal_sampler, double *return_value) {
     mui::mui_f_wrapper_3D::point_type point_fetch(static_cast<mui::mui_f_wrapper_3D::REAL>(*point_1,*point_2,*point_3));
     *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
             static_cast<mui::mui_f_wrapper_3D::time_type>(*t), *spatial_sampler, *temporal_sampler));
@@ -2841,7 +2972,7 @@ void mui_fetch_nearest_neighbor_sum_3t_pair_f(mui_uniface_3t *uniface, const cha
             *spatial_sampler, *temporal_sampler));
 }
 
-// Spatial sampler: nearest neighbor; temporal sampler: exact
+// Spatial sampler: pseudo nearest neighbor; temporal sampler: exact
 void mui_fetch_pseudo_nearest_neighbor_exact_3f_pair_f(mui_uniface_3f *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
         float* t, float* it, mui_sampler_pseudo_nearest_neighbor_3f *spatial_sampler,
         mui_temporal_sampler_exact_3f *temporal_sampler, float *return_value) {
@@ -2877,7 +3008,7 @@ void mui_fetch_pseudo_nearest_neighbor_exact_3t_pair_f(mui_uniface_3t *uniface, 
             *spatial_sampler, *temporal_sampler));
 }
 
-// Spatial sampler: nearest neighbor; temporal sampler: gauss
+// Spatial sampler: pseudo nearest neighbor; temporal sampler: gauss
 void mui_fetch_pseudo_nearest_neighbor_gauss_3f_pair_f(mui_uniface_3f *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
         float* t, float* it, mui_sampler_pseudo_nearest_neighbor_3f *spatial_sampler,
         mui_temporal_sampler_gauss_3f *temporal_sampler, float *return_value) {
@@ -2913,7 +3044,7 @@ void mui_fetch_pseudo_nearest_neighbor_gauss_3t_pair_f(mui_uniface_3t *uniface, 
             *spatial_sampler, *temporal_sampler));
 }
 
-// Spatial sampler: nearest neighbor; temporal sampler: mean
+// Spatial sampler: pseudo nearest neighbor; temporal sampler: mean
 void mui_fetch_pseudo_nearest_neighbor_mean_3f_pair_f(mui_uniface_3f *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
         float* t, float* it, mui_sampler_pseudo_nearest_neighbor_3f *spatial_sampler,
         mui_temporal_sampler_mean_3f *temporal_sampler, float *return_value) {
@@ -2949,7 +3080,7 @@ void mui_fetch_pseudo_nearest_neighbor_mean_3t_pair_f(mui_uniface_3t *uniface, c
             *spatial_sampler, *temporal_sampler));
 }
 
-// Spatial sampler: nearest neighbor; temporal sampler: sum
+// Spatial sampler: pseudo nearest neighbor; temporal sampler: sum
 void mui_fetch_pseudo_nearest_neighbor_sum_3f_pair_f(mui_uniface_3f *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
         float* t, float* it, mui_sampler_pseudo_nearest_neighbor_3f *spatial_sampler,
         mui_temporal_sampler_sum_3f *temporal_sampler, float *return_value) {
@@ -2978,6 +3109,150 @@ void mui_fetch_pseudo_nearest_neighbor_sum_3dx_pair_f(mui_uniface_3dx *uniface, 
 
 void mui_fetch_pseudo_nearest_neighbor_sum_3t_pair_f(mui_uniface_3t *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
         double* t, double* it, mui_sampler_pseudo_nearest_neighbor_3t *spatial_sampler,
+        mui_temporal_sampler_sum_3t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_3D::point_type point_fetch(static_cast<mui::mui_f_wrapper_3D::REAL>(*point_1,*point_2,*point_3));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_3D::time_type>(*t), static_cast<mui::mui_f_wrapper_3D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: pseudo nearest neighbor linear; temporal sampler: exact
+void mui_fetch_pseudo_n2_linear_exact_3f_pair_f(mui_uniface_3f *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
+        float* t, float* it, mui_sampler_pseudo_n2_linear_3f *spatial_sampler,
+        mui_temporal_sampler_exact_3f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3f(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_exact_3fx_pair_f(mui_uniface_3fx *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
+        float* t, float* it, mui_sampler_pseudo_n2_linear_3fx *spatial_sampler,
+        mui_temporal_sampler_exact_3fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3fx(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_exact_3d_pair_f(mui_uniface_3d *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3d *spatial_sampler,
+        mui_temporal_sampler_exact_3d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3d(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_exact_3dx_pair_f(mui_uniface_3dx *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3dx *spatial_sampler,
+        mui_temporal_sampler_exact_3dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3dx(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_exact_3t_pair_f(mui_uniface_3t *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3t *spatial_sampler,
+        mui_temporal_sampler_exact_3t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_3D::point_type point_fetch(static_cast<mui::mui_f_wrapper_3D::REAL>(*point_1,*point_2,*point_3));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_3D::time_type>(*t), static_cast<mui::mui_f_wrapper_3D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: pseudo nearest neighbor linear; temporal sampler: gauss
+void mui_fetch_pseudo_n2_linear_gauss_3f_pair_f(mui_uniface_3f *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
+        float* t, float* it, mui_sampler_pseudo_n2_linear_3f *spatial_sampler,
+        mui_temporal_sampler_gauss_3f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3f(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_gauss_3fx_pair_f(mui_uniface_3fx *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
+        float* t, float* it, mui_sampler_pseudo_n2_linear_3fx *spatial_sampler,
+        mui_temporal_sampler_gauss_3fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3fx(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_gauss_3d_pair_f(mui_uniface_3d *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3d *spatial_sampler,
+        mui_temporal_sampler_gauss_3d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3d(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_gauss_3dx_pair_f(mui_uniface_3dx *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3dx *spatial_sampler,
+        mui_temporal_sampler_gauss_3dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3dx(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_gauss_3t_pair_f(mui_uniface_3t *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3t *spatial_sampler,
+        mui_temporal_sampler_gauss_3t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_3D::point_type point_fetch(static_cast<mui::mui_f_wrapper_3D::REAL>(*point_1,*point_2,*point_3));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_3D::time_type>(*t), static_cast<mui::mui_f_wrapper_3D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: pseudo nearest neighbor linear; temporal sampler: mean
+void mui_fetch_pseudo_n2_linear_mean_3f_pair_f(mui_uniface_3f *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
+        float* t, float* it, mui_sampler_pseudo_n2_linear_3f *spatial_sampler,
+        mui_temporal_sampler_mean_3f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3f(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_mean_3fx_pair_f(mui_uniface_3fx *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
+        float* t, float* it, mui_sampler_pseudo_n2_linear_3fx *spatial_sampler,
+        mui_temporal_sampler_mean_3fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3fx(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_mean_3d_pair_f(mui_uniface_3d *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3d *spatial_sampler,
+        mui_temporal_sampler_mean_3d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3d(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_mean_3dx_pair_f(mui_uniface_3dx *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3dx *spatial_sampler,
+        mui_temporal_sampler_mean_3dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3dx(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_mean_3t_pair_f(mui_uniface_3t *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3t *spatial_sampler,
+        mui_temporal_sampler_mean_3t *temporal_sampler, double *return_value) {
+    mui::mui_f_wrapper_3D::point_type point_fetch(static_cast<mui::mui_f_wrapper_3D::REAL>(*point_1,*point_2,*point_3));
+    *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,
+            static_cast<mui::mui_f_wrapper_3D::time_type>(*t), static_cast<mui::mui_f_wrapper_3D::iterator_type>(*it),
+            *spatial_sampler, *temporal_sampler));
+}
+
+// Spatial sampler: pseudo nearest neighbor linear; temporal sampler: sum
+void mui_fetch_pseudo_n2_linear_sum_3f_pair_f(mui_uniface_3f *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
+        float* t, float* it, mui_sampler_pseudo_n2_linear_3f *spatial_sampler,
+        mui_temporal_sampler_sum_3f *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3f(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_sum_3fx_pair_f(mui_uniface_3fx *uniface, const char *attr, float* point_1, float* point_2, float* point_3,
+        float* t, float* it, mui_sampler_pseudo_n2_linear_3fx *spatial_sampler,
+        mui_temporal_sampler_sum_3fx *temporal_sampler, float *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3fx(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_sum_3d_pair_f(mui_uniface_3d *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3d *spatial_sampler,
+        mui_temporal_sampler_sum_3d *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3d(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler, *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_sum_3dx_pair_f(mui_uniface_3dx *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3dx *spatial_sampler,
+        mui_temporal_sampler_sum_3dx *temporal_sampler, double *return_value) {
+    *return_value = uniface->fetch(std::string(attr), mui::point3dx(*point_1,*point_2,*point_3), *t, *it, *spatial_sampler,
+            *temporal_sampler);
+}
+
+void mui_fetch_pseudo_n2_linear_sum_3t_pair_f(mui_uniface_3t *uniface, const char *attr, double* point_1, double* point_2, double* point_3,
+        double* t, double* it, mui_sampler_pseudo_n2_linear_3t *spatial_sampler,
         mui_temporal_sampler_sum_3t *temporal_sampler, double *return_value) {
     mui::mui_f_wrapper_3D::point_type point_fetch(static_cast<mui::mui_f_wrapper_3D::REAL>(*point_1,*point_2,*point_3));
     *return_value = static_cast<double>(uniface->fetch(std::string(attr), point_fetch,

--- a/wrappers/Fortran/mui_f_wrapper_3d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_3d.f90
@@ -2228,6 +2228,190 @@ module mui_3d_f
       real(kind=c_double), intent(out) :: return_value
     end subroutine mui_fetch_pseudo_nearest_neighbor_sum_3t_f
 
+    !Spatial sampler: pseudo nearest neighbor linear; temporal sampler: exact
+    subroutine mui_fetch_pseudo_n2_linear_exact_3f_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_exact_3f_f
+
+    subroutine mui_fetch_pseudo_n2_linear_exact_3fx_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_exact_3fx_f
+
+    subroutine mui_fetch_pseudo_n2_linear_exact_3d_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_exact_3d_f
+
+    subroutine mui_fetch_pseudo_n2_linear_exact_3dx_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_exact_3dx_f
+
+    subroutine mui_fetch_pseudo_n2_linear_exact_3t_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_exact_3t_f
+
+    !Spatial sampler: pseudo nearest neighbor; temporal sampler: gauss
+    subroutine mui_fetch_pseudo_n2_linear_gauss_3f_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_gauss_3f_f
+
+    subroutine mui_fetch_pseudo_n2_linear_gauss_3fx_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_gauss_3fx_f
+
+    subroutine mui_fetch_pseudo_n2_linear_gauss_3d_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_gauss_3d_f
+
+    subroutine mui_fetch_pseudo_n2_linear_gauss_3dx_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_gauss_3dx_f
+
+    subroutine mui_fetch_pseudo_n2_linear_gauss_3t_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_gauss_3t_f
+
+    !Spatial sampler: pseudo nearest neighbor linear; temporal sampler: mean
+    subroutine mui_fetch_pseudo_n2_linear_mean_3f_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_mean_3f_f
+
+    subroutine mui_fetch_pseudo_n2_linear_mean_3fx_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_mean_3fx_f
+
+    subroutine mui_fetch_pseudo_n2_linear_mean_3d_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_mean_3d_f
+
+    subroutine mui_fetch_pseudo_n2_linear_mean_3dx_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_mean_3dx_f
+
+    subroutine mui_fetch_pseudo_n2_linear_mean_3t_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_mean_3t_f
+
+    !Spatial sampler: pseudo nearest neighbor linear; temporal sampler: sum
+    subroutine mui_fetch_pseudo_n2_linear_sum_3f_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_sum_3f_f
+
+    subroutine mui_fetch_pseudo_n2_linear_sum_3fx_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_sum_3fx_f
+
+    subroutine mui_fetch_pseudo_n2_linear_sum_3d_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_sum_3d_f
+
+    subroutine mui_fetch_pseudo_n2_linear_sum_3dx_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_sum_3dx_f
+
+    subroutine mui_fetch_pseudo_n2_linear_sum_3t_f(uniface,attr,point_1,point_2,point_3,t,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_sum_3t_f
+
     !Spatial sampler: shepard quintic; temporal sampler: exact
     subroutine mui_fetch_shepard_quintic_exact_3f_f(uniface,attr,point_1,point_2,point_3,t, &
       spatial_sampler,temporal_sampler, &
@@ -3967,6 +4151,190 @@ module mui_3d_f
       real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
       real(kind=c_double), intent(out) :: return_value
     end subroutine mui_fetch_pseudo_nearest_neighbor_sum_3t_pair_f
+
+    !Spatial sampler: pseudo nearest neighbor linear; temporal sampler: exact
+    subroutine mui_fetch_pseudo_n2_linear_exact_3f_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_exact_3f_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_exact_3fx_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_exact_3fx_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_exact_3d_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_exact_3d_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_exact_3dx_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_exact_3dx_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_exact_3t_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_exact_3t_pair_f
+
+    !Spatial sampler: pseudo nearest neighbor linear; temporal sampler: gauss
+    subroutine mui_fetch_pseudo_n2_linear_gauss_3f_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_gauss_3f_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_gauss_3fx_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_gauss_3fx_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_gauss_3d_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_gauss_3d_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_gauss_3dx_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_gauss_3dx_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_gauss_3t_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_gauss_3t_pair_f
+
+    !Spatial sampler: pseudo nearest neighbor linear; temporal sampler: mean
+    subroutine mui_fetch_pseudo_n2_linear_mean_3f_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_mean_3f_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_mean_3fx_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_mean_3fx_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_mean_3d_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_mean_3d_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_mean_3dx_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_mean_3dx_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_mean_3t_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_mean_3t_pair_f
+
+    !Spatial sampler: pseudo nearest neighbor linear; temporal sampler: sum
+    subroutine mui_fetch_pseudo_n2_linear_sum_3f_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_sum_3f_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_sum_3fx_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_float
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_float), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_sum_3fx_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_sum_3d_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_sum_3d_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_sum_3dx_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_sum_3dx_pair_f
+
+    subroutine mui_fetch_pseudo_n2_linear_sum_3t_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
+    spatial_sampler,temporal_sampler,return_value) bind(C)
+      import :: c_ptr,c_char,c_double
+      type(c_ptr), intent(in), value :: uniface,spatial_sampler,temporal_sampler
+      character(kind=c_char), intent(in) :: attr(*)
+      real(kind=c_double), intent(in) :: point_1,point_2,point_3,t_1,t_2
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fetch_pseudo_n2_linear_sum_3t_pair_f
 
     !Spatial sampler: shepard quintic; temporal sampler: exact
     subroutine mui_fetch_shepard_quintic_exact_3f_pair_f(uniface,attr,point_1,point_2,point_3,t_1,t_2,&
@@ -6164,21 +6532,21 @@ module mui_3d_f
     end subroutine mui_set_forget_length_3fx_f
 
     subroutine mui_set_forget_length_3d_f(uniface,length) bind(C)
-      import :: c_ptr,c_float
+      import :: c_ptr,c_double
       type(c_ptr), intent(in), value :: uniface
-      real(kind=c_float), intent(in), value :: length
+      real(kind=c_double), intent(in), value :: length
     end subroutine mui_set_forget_length_3d_f
 
     subroutine mui_set_forget_length_3dx_f(uniface,length) bind(C)
-      import :: c_ptr,c_float
+      import :: c_ptr,c_double
       type(c_ptr), intent(in), value :: uniface
-      real(kind=c_float), intent(in), value :: length
+      real(kind=c_double), intent(in), value :: length
     end subroutine mui_set_forget_length_3dx_f
 
     subroutine mui_set_forget_length_3t_f(uniface,length) bind(C)
-      import :: c_ptr,c_float
+      import :: c_ptr,c_double
       type(c_ptr), intent(in), value :: uniface
-      real(kind=c_float), intent(in), value :: length
+      real(kind=c_double), intent(in), value :: length
     end subroutine mui_set_forget_length_3t_f
 
     !******************************************

--- a/wrappers/Fortran/mui_f_wrapper_general.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_general.cpp
@@ -62,4 +62,12 @@ void mui_mpi_split_by_app_threaded_f(MPI_Comm **communicator, int *argc, char **
 	*communicator = reinterpret_cast<MPI_Comm*>(mui::mpi_split_by_app(*argc, *argv, *threadType, *thread_support));
 }
 
+void mui_mpi_get_size_f(MPI_Comm *communicator, int *size) {
+	MPI_Comm_size(*communicator, size);
+}
+
+void mui_mpi_get_rank_f(MPI_Comm *communicator, int *rank) {
+	MPI_Comm_rank(*communicator, rank);
+}
+
 }

--- a/wrappers/Fortran/mui_f_wrapper_general.f90
+++ b/wrappers/Fortran/mui_f_wrapper_general.f90
@@ -68,6 +68,20 @@ module mui_general_f
       character(kind=c_char), intent(in), dimension(argc) :: argv(*)
     end subroutine mui_mpi_split_by_app_threaded_f
 
+    !Function to get MPI size
+    subroutine mui_mpi_get_size_f(communicator,local_size) bind(C)
+      import :: c_ptr,c_int
+      type(c_ptr), intent(out), target :: communicator(*)
+      integer(kind=c_int), intent(in) :: local_size
+    end subroutine mui_mpi_get_size_f
+
+    !Function to get MPI rank
+    subroutine mui_mpi_get_rank_f(communicator,local_rank) bind(C)
+      import :: c_ptr,c_int
+      type(c_ptr), intent(out), target :: communicator(*)
+      integer(kind=c_int), intent(in) :: local_rank
+    end subroutine mui_mpi_get_rank_f
+
   end interface 
 
 end module mui_general_f

--- a/wrappers/Fortran/unit_test.f90
+++ b/wrappers/Fortran/unit_test.f90
@@ -52,6 +52,7 @@ program main
   use mui_1d_f
   use mui_2d_f
   use mui_3d_f
+  use mui_general_f
 
   implicit none
 

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -42,9 +42,10 @@ find_package(
 # target_link_libraries
 pybind11_add_module(mui4py_mod MODULE
   mui4py/cpp/mui4py.cpp
+  mui4py/cpp/geometry.cpp
   mui4py/cpp/sampler.cpp
   mui4py/cpp/temporal_sampler.cpp
-  mui4py/cpp/geometry.cpp
+  mui4py/cpp/algorithm.cpp
   mui4py/cpp/uniface1d.cpp
   mui4py/cpp/uniface2d.cpp
   mui4py/cpp/uniface3d.cpp

--- a/wrappers/Python/mui4py/__init__.py
+++ b/wrappers/Python/mui4py/__init__.py
@@ -52,9 +52,10 @@ from mui4py.mui4py import Uniface, mpi_split_by_app, set_quiet,\
 from mui4py.samplers import SamplerExact, SamplerGauss, SamplerMovingAverage,\
                             SamplerNearestNeighbor, SamplerPseudoNearest2Linear,\
                             SamplerPseudoNearestNeighbor, SamplerSherpardQuintic,\
-                            SamplerSphQuintic, SamplerSumQuintic, SamplerRbf,\
-                            TemporalSamplerExact, TemporalSamplerGauss,\
+                            SamplerSphQuintic, SamplerSumQuintic, SamplerRbf
+from mui4py.temporal_samplers import TemporalSamplerExact, TemporalSamplerGauss,\
                             TemporalSamplerMean, TemporalSamplerSum
+from mui4py.algorithms import AlgorithmFixedRelaxation, AlgorithmAitken
 from mui4py.types import STRING, INT32, INT64, INT, UINT32, UINT64, UINT, FLOAT32, FLOAT64, FLOAT, BOOL
 from mui4py.config import Config, set_default_config, get_default_config
 import mui4py.geometry

--- a/wrappers/Python/mui4py/algorithms.py
+++ b/wrappers/Python/mui4py/algorithms.py
@@ -1,0 +1,114 @@
+"""
+##############################################################################
+# Multiscale Universal Interface Code Coupling Library                       #
+#                                                                            #
+# Copyright (C) 2023 W. Liu                                                  #
+#                                                                            #
+# This software is jointly licensed under the Apache License, Version 2.0    #
+# and the GNU General Public License version 3, you may use it according     #
+# to either.                                                                 #
+#                                                                            #
+# ** Apache License, version 2.0 **                                          #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License");            #
+# you may not use this file except in compliance with the License.           #
+# You may obtain a copy of the License at                                    #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#                                                                            #
+# ** GNU General Public License, version 3 **                                #
+#                                                                            #
+# This program is free software: you can redistribute it and/or modify       #
+# it under the terms of the GNU General Public License as published by       #
+# the Free Software Foundation, either version 3 of the License, or          #
+# (at your option) any later version.                                        #
+#                                                                            #
+# This program is distributed in the hope that it will be useful,            #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              #
+# GNU General Public License for more details.                               #
+#                                                                            #
+# You should have received a copy of the GNU General Public License          #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.      #
+##############################################################################
+#
+# @file algorithms.py
+# @author W. Liu
+# @date 18 March 2019
+# @brief Coupling algorithms for the MUI Python wrapper.
+#
+"""
+
+from mui4py.common import CppClass
+from mui4py.config import Config
+from mui4py.types import UINT, UINT32, UINT64, FLOAT, FLOAT32, FLOAT64, INT, INT32, INT64, STRING, BOOL
+
+# Interface for TemporalSampler
+def algorithm_signature(self):
+    sig = self._split_class_name(title=False)
+    return sig
+
+# Algorithms
+class Algorithm(CppClass):
+    def __init__(self, config=None, args=(), kwargs={}):
+        if config is not None:
+            super(Algorithm, self).__init__(config, args, kwargs)
+            self.configure(self.config)
+        else:
+            # Empty config to not trigger error in default config.
+            super(Algorithm, self).__init__(Config(), args, kwargs)
+
+Algorithm.fetch_signature = algorithm_signature
+
+class AlgorithmFixedRelaxation(Algorithm):
+    def __init__(self, under_relaxation_factor=None, pts_value_init=None, config=None):
+        if config is None:
+            self.config=Config()
+        if pts_value_init is not None:
+            super(AlgorithmFixedRelaxation, self).__init__(config, args=(under_relaxation_factor, pts_value_init))
+        else:
+            if under_relaxation_factor is not None:
+                super(AlgorithmFixedRelaxation, self).__init__(config, args=(under_relaxation_factor,))
+            else:
+                super(AlgorithmFixedRelaxation, self).__init__()
+        self._ALLOWED_IO_TYPES = [INT, INT32, INT64, UINT, UINT32, UINT64, FLOAT, FLOAT32, FLOAT64]
+
+class AlgorithmAitken(Algorithm):
+    def __init__(self, under_relaxation_factor=None, under_relaxation_factor_max=None, local_comm=None, pts_vlu_init=None, res_l2_norm_nm1=None, config=None):
+        if config is None:
+            self.config=Config()
+        if res_l2_norm_nm1 is not None:
+            super(AlgorithmAitken, self).__init__(config, args=(under_relaxation_factor, under_relaxation_factor_max, local_comm, pts_vlu_init, res_l2_norm_nm1))
+        else:
+            if pts_vlu_init is not None:
+                super(AlgorithmAitken, self).__init__(config, args=(under_relaxation_factor, under_relaxation_factor_max, local_comm, pts_vlu_init, 0.0))
+            else:
+                if local_comm is not None:
+                    super(AlgorithmAitken, self).__init__(config, args=(under_relaxation_factor, under_relaxation_factor_max, local_comm, [], 0.0))
+                else:
+                    if under_relaxation_factor_max is not None:
+                        super(AlgorithmAitken, self).__init__(config, args=(under_relaxation_factor, under_relaxation_factor_max, None, [], 0.0))
+                    else:
+                        if under_relaxation_factor is not None:
+                            super(AlgorithmAitken, self).__init__(config, args=(under_relaxation_factor, 1.0, None, [], 0.0))
+                        else:
+                            super(AlgorithmAitken, self).__init__(config, args=(1.0, 1.0, None, [], 0.0))
+        self._ALLOWED_IO_TYPES = [INT, INT32, INT64, UINT, UINT32, UINT64, FLOAT, FLOAT32, FLOAT64]
+
+    def get_under_relaxation_factor(self, t1, t2=None):
+        if t2 is not None:
+            return self.raw.get_under_relaxation_factor(t1, t2)
+        else:
+            return self.raw.get_under_relaxation_factor(t1)
+
+    def get_residual_L2_Norm(self, t1, t2=None):
+        if t2 is not None:
+            return self.raw.get_residual_L2_Norm(t1, t2)
+        else:
+            return self.raw.get_residual_L2_Norm(t1)

--- a/wrappers/Python/mui4py/cpp/algorithm.cpp
+++ b/wrappers/Python/mui4py/cpp/algorithm.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson                                           *
+* Copyright (C) 2023 W. Liu                                                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -38,62 +38,90 @@
 *****************************************************************************/
 
 /**
- * @file temporal_sampler.cpp
- * @author C. Richardson
- * @date 20 January 2023
- * @brief Temporal samplers for MUI Python wrapper.
+ * @file algorithm.cpp
+ * @author W. Liu
+ * @date 18 March 2023
+ * @brief Algorithms for MUI Python wrapper.
  */
 
-#include "../../../../src/mui.h"
+#include <mui.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/numpy.h>
+#include <mpi4py/mpi4py.h>
 #include <string>
 #include "config_name.h"
 
 template <typename Tconfig>
-void declare_temporal_samplers(py::module &m)
+void declare_algorithms(py::module &m)
 {
-    std::string name = "_Temporal_sampler_exact" + config_name<Tconfig>();
-    using Ttime = typename Tconfig::time_type;
-    py::class_<mui::temporal_sampler_exact<Tconfig>>(m, name.c_str())
-        .def(py::init<Ttime>(), py::arg("tol") = std::numeric_limits<Ttime>::epsilon());
-
-    name = "_Temporal_sampler_gauss" + config_name<Tconfig>();
+	std::string name = "_Algorithm_fixed_relaxation" + config_name<Tconfig>();
+    using TclassFR = mui::algo_fixed_relaxation<Tconfig>;
     using Treal = typename Tconfig::REAL;
-    using Ttime = typename Tconfig::time_type;
-    py::class_<mui::temporal_sampler_gauss<Tconfig>>(m, name.c_str()).def(py::init<Ttime, Treal>());
+    using Tpoint = typename Tconfig::point_type;
+    py::class_<TclassFR> algo_fixed_relaxation(m, name.c_str());
+    algo_fixed_relaxation.def(py::init<Treal, std::vector<std::pair<Tpoint, Treal>>>(), py::arg("under_relaxation_factor") = Treal(1.0), py::arg("pts_value_init") = std::vector<std::pair<Tpoint, Treal>>());
 
-    name = "_Temporal_sampler_mean" + config_name<Tconfig>();
+    name = "_Algorithm_aitken" + config_name<Tconfig>();
+    using TclassAitken = mui::algo_aitken<Tconfig>;
+    using Treal = typename Tconfig::REAL;
+    using Tpoint = typename Tconfig::point_type;
     using Ttime = typename Tconfig::time_type;
-    py::class_<mui::temporal_sampler_mean<Tconfig>>(m, name.c_str())
-        .def(py::init<Ttime, Ttime>(), py::arg("newleft") = Ttime(0),
-             py::arg("newright") = Ttime(0));
+    using Titer = typename Tconfig::iterator_type;
+    py::class_<TclassAitken> algo_aitken(m, name.c_str());
+    algo_aitken.def(py::init([](Treal under_relaxation_factor = 1.0,
+    		    		    	Treal under_relaxation_factor_max = 1.0,
+								pybind11::handle const& local_comm = py::none(),
+								std::vector<std::pair<Tpoint, Treal>> pts_vlu_init = std::vector<std::pair<Tpoint, Treal>>(),
+								Treal res_l2_norm_nm1 = 0.0) {
 
-    name = "_Temporal_sampler_sum" + config_name<Tconfig>();
-    using Tclass = mui::temporal_sampler_sum<Tconfig>;
-    using Ttime = typename Tconfig::time_type;
-    py::class_<Tclass>(m, name.c_str())
-        .def(py::init<Ttime, Ttime>(), py::arg("newleft") = Ttime(0),
-             py::arg("newright") = Ttime(0));
+				// Import mpi4py if it does not exist.
+				if (!PyMPIComm_Get)
+				{
+					if (import_mpi4py() < 0)
+					{
+						throw std::runtime_error(
+							"MUI Error [wrappers/Python/mui4py/cpp/algorithm.cpp]: mpi4py not loaded correctly\n");
+					}
+				}
+
+				MPI_Comm ric_mpiComm;
+
+				if (local_comm.is_none()) {
+					MPI_Comm comm = MPI_COMM_NULL;
+					ric_mpiComm = reinterpret_cast<MPI_Comm>(comm);
+				} else {
+					PyObject *py_src = local_comm.ptr();
+					MPI_Comm *comm_p = PyMPIComm_Get(py_src);
+					ric_mpiComm = reinterpret_cast<MPI_Comm>(*comm_p);
+				}
+
+                return new mui::algo_aitken<Tconfig>(under_relaxation_factor,
+                									 under_relaxation_factor_max,
+													 ric_mpiComm,
+													 pts_vlu_init,
+													 res_l2_norm_nm1);
+    }))
+               .def("get_under_relaxation_factor", (Treal(TclassAitken::*)(Ttime)) &TclassAitken::get_under_relaxation_factor, "")
+               .def("get_under_relaxation_factor", (Treal(TclassAitken::*)(Ttime, Titer)) &TclassAitken::get_under_relaxation_factor, "")
+               .def("get_residual_L2_Norm", (Treal(TclassAitken::*)(Ttime)) &TclassAitken::get_residual_L2_Norm, "")
+               .def("get_residual_L2_Norm", (Treal(TclassAitken::*)(Ttime, Titer)) &TclassAitken::get_residual_L2_Norm, "");
 }
 
-void temporal_sampler(py::module &m)
+void algorithm(py::module &m)
 {
 #ifdef PYTHON_INT_64
-    declare_temporal_samplers<mui::mui_config_1dx>(m);
-    declare_temporal_samplers<mui::mui_config_2dx>(m);
-    declare_temporal_samplers<mui::mui_config_3dx>(m);
-    declare_temporal_samplers<mui::mui_config_1fx>(m);
-    declare_temporal_samplers<mui::mui_config_2fx>(m);
-    declare_temporal_samplers<mui::mui_config_3fx>(m);
+	declare_algorithms<mui::mui_config_1dx>(m);
+	declare_algorithms<mui::mui_config_2dx>(m);
+	declare_algorithms<mui::mui_config_3dx>(m);
+	declare_algorithms<mui::mui_config_1fx>(m);
+	declare_algorithms<mui::mui_config_2fx>(m);
+	declare_algorithms<mui::mui_config_3fx>(m);
 #elif defined PYTHON_INT_32
-    declare_temporal_samplers<mui::mui_config_1d>(m);
-    declare_temporal_samplers<mui::mui_config_2d>(m);
-    declare_temporal_samplers<mui::mui_config_3d>(m);
-    declare_temporal_samplers<mui::mui_config_1f>(m);
-    declare_temporal_samplers<mui::mui_config_2f>(m);
-    declare_temporal_samplers<mui::mui_config_3f>(m);
+	declare_algorithms<mui::mui_config_1d>(m);
+	declare_algorithms<mui::mui_config_2d>(m);
+	declare_algorithms<mui::mui_config_3d>(m);
+	declare_algorithms<mui::mui_config_1f>(m);
+	declare_algorithms<mui::mui_config_2f>(m);
+	declare_algorithms<mui::mui_config_3f>(m);
 #else
 #error PYTHON_INT_[32|64] not defined.
 #endif

--- a/wrappers/Python/mui4py/cpp/algorithm_name.h
+++ b/wrappers/Python/mui4py/cpp/algorithm_name.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
 * Multiscale Universal Interface Code Coupling Library                       *
 *                                                                            *
-* Copyright (C) 2023 C. Richardson                                           *
+* Copyright (C) 2023 W. Liu                                                  *
 *                                                                            *
 * This software is jointly licensed under the Apache License, Version 2.0    *
 * and the GNU General Public License version 3, you may use it according     *
@@ -38,63 +38,18 @@
 *****************************************************************************/
 
 /**
- * @file temporal_sampler.cpp
- * @author C. Richardson
- * @date 20 January 2023
- * @brief Temporal samplers for MUI Python wrapper.
+ * @file algorithm_name.h
+ * @author W. Liu
+ * @date 18 March 2023
+ * @brief Algorithm names for MUI Python wrapper.
  */
 
-#include "../../../../src/mui.h"
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/numpy.h>
-#include <string>
-#include "config_name.h"
-
-template <typename Tconfig>
-void declare_temporal_samplers(py::module &m)
+template <typename Tconfig, template <typename> class Talgorithm>
+std::string algorithm_name()
 {
-    std::string name = "_Temporal_sampler_exact" + config_name<Tconfig>();
-    using Ttime = typename Tconfig::time_type;
-    py::class_<mui::temporal_sampler_exact<Tconfig>>(m, name.c_str())
-        .def(py::init<Ttime>(), py::arg("tol") = std::numeric_limits<Ttime>::epsilon());
-
-    name = "_Temporal_sampler_gauss" + config_name<Tconfig>();
-    using Treal = typename Tconfig::REAL;
-    using Ttime = typename Tconfig::time_type;
-    py::class_<mui::temporal_sampler_gauss<Tconfig>>(m, name.c_str()).def(py::init<Ttime, Treal>());
-
-    name = "_Temporal_sampler_mean" + config_name<Tconfig>();
-    using Ttime = typename Tconfig::time_type;
-    py::class_<mui::temporal_sampler_mean<Tconfig>>(m, name.c_str())
-        .def(py::init<Ttime, Ttime>(), py::arg("newleft") = Ttime(0),
-             py::arg("newright") = Ttime(0));
-
-    name = "_Temporal_sampler_sum" + config_name<Tconfig>();
-    using Tclass = mui::temporal_sampler_sum<Tconfig>;
-    using Ttime = typename Tconfig::time_type;
-    py::class_<Tclass>(m, name.c_str())
-        .def(py::init<Ttime, Ttime>(), py::arg("newleft") = Ttime(0),
-             py::arg("newright") = Ttime(0));
-}
-
-void temporal_sampler(py::module &m)
-{
-#ifdef PYTHON_INT_64
-    declare_temporal_samplers<mui::mui_config_1dx>(m);
-    declare_temporal_samplers<mui::mui_config_2dx>(m);
-    declare_temporal_samplers<mui::mui_config_3dx>(m);
-    declare_temporal_samplers<mui::mui_config_1fx>(m);
-    declare_temporal_samplers<mui::mui_config_2fx>(m);
-    declare_temporal_samplers<mui::mui_config_3fx>(m);
-#elif defined PYTHON_INT_32
-    declare_temporal_samplers<mui::mui_config_1d>(m);
-    declare_temporal_samplers<mui::mui_config_2d>(m);
-    declare_temporal_samplers<mui::mui_config_3d>(m);
-    declare_temporal_samplers<mui::mui_config_1f>(m);
-    declare_temporal_samplers<mui::mui_config_2f>(m);
-    declare_temporal_samplers<mui::mui_config_3f>(m);
-#else
-#error PYTHON_INT_[32|64] not defined.
-#endif
+  if (std::is_same<Talgorithm<Tconfig>, mui::algo_fixed_relaxation<Tconfig>>::value)
+    return "algorithm_fixed_relaxation";
+  if (std::is_same<Talgorithm<Tconfig>, mui::algo_aitken<Tconfig>>::value)
+    return "algorithm_aitken";
+  throw std::runtime_error("Invalid temporal sampler type");
 }

--- a/wrappers/Python/mui4py/cpp/mui4py.cpp
+++ b/wrappers/Python/mui4py/cpp/mui4py.cpp
@@ -56,9 +56,10 @@
 #include "compiler_info.h"
 
 // Declaration of other files
-void temporal_sampler(py::module &m);
-void sampler(py::module &m);
 void geometry(py::module &m);
+void sampler(py::module &m);
+void temporal_sampler(py::module &m);
+void algorithm(py::module &m);
 void uniface1d(py::module &m);
 void uniface2d(py::module &m);
 void uniface3d(py::module &m);
@@ -78,6 +79,7 @@ PYBIND11_MODULE(mui4py_mod, m)
   geometry(m);
   sampler(m);
   temporal_sampler(m);
+  algorithm(m);
   uniface1d(m);
   uniface2d(m);
   uniface3d(m);

--- a/wrappers/Python/mui4py/cpp/sampler.cpp
+++ b/wrappers/Python/mui4py/cpp/sampler.cpp
@@ -248,26 +248,50 @@ void declare_sampler_sum_quintic(py::module &m)
 }
 
 // SPATIAL_SAMPLER_RBF CLASS//
-//template <typename Tconfig, typename T>
-//void declare_sampler_rbf_t(py::module &m)
-//{
-//    std::string name = "_Sampler_rbf" + config_name<Tconfig>() + "_" + type_name<T>();
-//    using Treal = typename Tconfig::REAL;
-//    using Tint = typename Tconfig::INT;
-//    using Tpoint = typename Tconfig::point_type;
-//    using Tclass = mui::sampler_rbf<Tconfig, T, T>;
-//    py::class_<Tclass>(m, name.c_str()).def(py::init<Treal, std::vector<Tpoint> &, Tint,
-//    		bool, bool, Treal, Treal, Tint, Tint, Tint, PyMPIComm_New(MPI_Comm)>());
-//}
-//
-//template <typename Tconfig>
-//void declare_sampler_rbf(py::module &m)
-//{
-//    declare_sampler_rbf_t<Tconfig, double>(m);
-//    declare_sampler_rbf_t<Tconfig, float>(m);
-//    declare_sampler_rbf_t<Tconfig, std::int32_t>(m);
-//    declare_sampler_rbf_t<Tconfig, std::int64_t>(m);
-//}
+template <typename Tconfig, typename T = void>
+void declare_sampler_rbf_t(py::module &m)
+{
+    std::string name = "_Sampler_rbf" + config_name<Tconfig>() + "_" + type_name<T>();
+    using Treal = typename Tconfig::REAL;
+    using Tint = typename Tconfig::INT;
+    using Tpoint = typename Tconfig::point_type;
+    using Tclass = mui::sampler_rbf<Tconfig, T, T>;
+    py::class_<Tclass>(m, name.c_str())
+            .def(py::init([](Treal r, const std::vector<Tpoint>& pointvect, Tint basisFunc, bool conservative, bool smoothFunc, bool writeMatrix, const std::string& writeFileAddress, Treal cutoff, Treal cgSolveTol, Tint cgMaxIter, Tint pouSize, Tint precond, pybind11::handle const& world) {
+                // Import mpi4py if it does not exist.
+                if (!PyMPIComm_Get)
+                {
+                    if (import_mpi4py() < 0)
+                    {
+                        throw std::runtime_error(
+                            "MUI Error [wrappers/Python/mui4py/cpp/sampler.cpp]: mpi4py not loaded correctly\n");
+                    }
+                }
+
+                MPI_Comm comm;
+                MPI_Comm ric_mpiComm;
+
+                if (world.is_none()) {
+                    comm = MPI_COMM_NULL;
+                    ric_mpiComm = reinterpret_cast<MPI_Comm>(comm);
+                } else {
+                    PyObject *py_src = world.ptr();
+                    MPI_Comm *comm_p = PyMPIComm_Get(py_src);
+                    ric_mpiComm = reinterpret_cast<MPI_Comm>(*comm_p);
+                }
+
+                return new Tclass(r, pointvect, basisFunc, conservative, smoothFunc, writeMatrix, writeFileAddress, cutoff, cgSolveTol, cgMaxIter, pouSize, precond, ric_mpiComm);
+        }));
+}
+
+template <typename Tconfig>
+void declare_sampler_rbf(py::module &m)
+{
+    declare_sampler_rbf_t<Tconfig, double>(m);
+    declare_sampler_rbf_t<Tconfig, float>(m);
+    declare_sampler_rbf_t<Tconfig, std::int32_t>(m);
+    declare_sampler_rbf_t<Tconfig, std::int64_t>(m);
+}
 
 template <typename Tconfig>
 void declare_samplers(py::module &m)
@@ -283,7 +307,7 @@ void declare_samplers(py::module &m)
     declare_sampler_shepard_quintic<Tconfig>(m);
     declare_sampler_sph_quintic<Tconfig>(m);
     declare_sampler_sum_quintic<Tconfig>(m);
-    //declare_sampler_rbf<Tconfig>(m);
+    declare_sampler_rbf<Tconfig>(m);
 }
 
 void sampler(py::module &m)

--- a/wrappers/Python/mui4py/cpp/sampler_name.h
+++ b/wrappers/Python/mui4py/cpp/sampler_name.h
@@ -65,5 +65,7 @@ std::string sampler_name()
     return "sph_quintic";
   if (std::is_same<Tsampler<Tconfig, T, T>, mui::sampler_sum_quintic<Tconfig, T, T>>::value)
     return "sum_quintic";
+  if (std::is_same<Tsampler<Tconfig, T, T>, mui::sampler_rbf<Tconfig, T, T>>::value)
+    return "rbf";
   throw std::runtime_error("Invalid sampler type");
 }

--- a/wrappers/Python/mui4py/cpp/uniface_base.h
+++ b/wrappers/Python/mui4py/cpp/uniface_base.h
@@ -51,6 +51,7 @@
 #include "config_name.h"
 #include "sampler_name.h"
 #include "temporal_name.h"
+#include "algorithm_name.h"
 
 template <typename Tconfig, typename T>
 void declare_uniface_fetch_single(py::class_<mui::uniface<Tconfig>> &uniface)
@@ -115,7 +116,7 @@ void declare_uniface_fetch_many(py::class_<mui::uniface<Tconfig>> &uniface)
                   const py::array_t<Treal, py::array::c_style>,
 				  const Ttime,
                   const Tsampler<Tconfig, T, T> &,
-                  const Ttemporal<Tconfig> &)) &
+                  const Ttemporal<Tconfig> &, bool)) &
                   Tclass::fetch_many,
               "");
 }
@@ -136,7 +137,94 @@ void declare_uniface_fetch_many_dual(py::class_<mui::uniface<Tconfig>> &uniface)
 				  const Ttime,
 				  const Titer,
                   const Tsampler<Tconfig, T, T> &,
-                  const Ttemporal<Tconfig> &)) &
+                  const Ttemporal<Tconfig> &, bool)) &
+                  Tclass::fetch_many,
+              "");
+}
+
+
+template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler, template <typename> class Ttemporal, template <typename> class Talgorithm>
+void declare_uniface_fetch_algo(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Treal = typename Tconfig::REAL;
+  using Ttime = typename Tconfig::time_type;
+
+  std::string fetch_name = "fetch_" + type_name<T>() + "_" + sampler_name<Tconfig, T, Tsampler>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>() + "_" + algorithm_name<Tconfig, Talgorithm>();
+  uniface.def(fetch_name.c_str(),
+              (T(Tclass::*)(
+                  const std::string &,
+				  const mui::point<Treal, Tconfig::D> &,
+				  const Ttime,
+                  const Tsampler<Tconfig, T, T> &,
+                  const Ttemporal<Tconfig> &,
+                  const Talgorithm<Tconfig> &,
+				  bool)) &
+                  Tclass::fetch,
+              "");
+}
+
+template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler, template <typename> class Ttemporal, template <typename> class Talgorithm>
+void declare_uniface_fetch_algo_dual(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Treal = typename Tconfig::REAL;
+  using Ttime = typename Tconfig::time_type;
+  using Titer = typename Tconfig::iterator_type;
+
+  std::string fetch_name = "fetch_dual_" + type_name<T>() + "_" + sampler_name<Tconfig, T, Tsampler>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>() + "_" + algorithm_name<Tconfig, Talgorithm>();
+  uniface.def(fetch_name.c_str(),
+           (T(Tclass::*)(
+               const std::string &,
+			   const mui::point<Treal, Tconfig::D> &,
+			   const Ttime,
+               const Titer,
+               const Tsampler<Tconfig, T, T> &,
+               const Ttemporal<Tconfig> &,
+			   const Talgorithm<Tconfig> &,
+			   bool)) &
+               Tclass::fetch,
+           "");
+}
+
+template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler, template <typename> class Ttemporal, template <typename> class Talgorithm>
+void declare_uniface_fetch_algo_many(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Treal = typename Tconfig::REAL;
+  using Ttime = typename Tconfig::time_type;
+
+  std::string fetch_many_name = "fetch_many_" + type_name<T>() + "_" + sampler_name<Tconfig, T, Tsampler>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>() + "_" + algorithm_name<Tconfig, Talgorithm>();
+  uniface.def(fetch_many_name.c_str(),
+              (py::array_t<T, py::array::c_style>(Tclass::*)(
+                  const std::string &,
+                  const py::array_t<Treal, py::array::c_style>,
+				  const Ttime,
+                  const Tsampler<Tconfig, T, T> &,
+                  const Ttemporal<Tconfig> &,
+				  const Talgorithm<Tconfig> &, bool)) &
+                  Tclass::fetch_many,
+              "");
+}
+
+template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler, template <typename> class Ttemporal, template <typename> class Talgorithm>
+void declare_uniface_fetch_algo_many_dual(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+  using Tclass = mui::uniface<Tconfig>;
+  using Treal = typename Tconfig::REAL;
+  using Ttime = typename Tconfig::time_type;
+  using Titer = typename Tconfig::iterator_type;
+
+  std::string fetch_many_name = "fetch_many_dual_" + type_name<T>() + "_" + sampler_name<Tconfig, T, Tsampler>() + "_" + temporal_sampler_name<Tconfig, Ttemporal>() + "_" + algorithm_name<Tconfig, Talgorithm>();
+  uniface.def(fetch_many_name.c_str(),
+              (py::array_t<T, py::array::c_style>(Tclass::*)(
+                  const std::string &,
+                  const py::array_t<Treal, py::array::c_style>,
+				  const Ttime,
+				  const Titer,
+                  const Tsampler<Tconfig, T, T> &,
+                  const Ttemporal<Tconfig> &,
+				  const Talgorithm<Tconfig> &, bool)) &
                   Tclass::fetch_many,
               "");
 }
@@ -217,6 +305,25 @@ void declare_uniface_fetch_values_dual(py::class_<mui::uniface<Tconfig>> &unifac
               "");
 }
 
+
+template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler, template <typename> class Ttemporal>
+void declare_uniface_fetch_all_algorithm(py::class_<mui::uniface<Tconfig>> &uniface)
+{
+
+  declare_uniface_fetch_algo<Tconfig, T, Tsampler, Ttemporal, mui::algo_fixed_relaxation>(uniface);
+  declare_uniface_fetch_algo<Tconfig, T, Tsampler, Ttemporal, mui::algo_aitken>(uniface);
+
+  declare_uniface_fetch_algo_dual<Tconfig, T, Tsampler, Ttemporal, mui::algo_fixed_relaxation>(uniface);
+  declare_uniface_fetch_algo_dual<Tconfig, T, Tsampler, Ttemporal, mui::algo_aitken>(uniface);
+
+  declare_uniface_fetch_algo_many<Tconfig, T, Tsampler, Ttemporal, mui::algo_fixed_relaxation>(uniface);
+  declare_uniface_fetch_algo_many<Tconfig, T, Tsampler, Ttemporal, mui::algo_aitken>(uniface);
+
+  declare_uniface_fetch_algo_many_dual<Tconfig, T, Tsampler, Ttemporal, mui::algo_fixed_relaxation>(uniface);
+  declare_uniface_fetch_algo_many_dual<Tconfig, T, Tsampler, Ttemporal, mui::algo_aitken>(uniface);
+}
+
+
 template <typename Tconfig, typename T, template <typename, typename, typename> class Tsampler>
 void declare_uniface_fetch_all_temporal(py::class_<mui::uniface<Tconfig>> &uniface)
 {
@@ -240,6 +347,11 @@ void declare_uniface_fetch_all_temporal(py::class_<mui::uniface<Tconfig>> &unifa
   declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
+
+  declare_uniface_fetch_all_algorithm<Tconfig, T, Tsampler, mui::temporal_sampler_exact>(uniface);
+  declare_uniface_fetch_all_algorithm<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
+  declare_uniface_fetch_all_algorithm<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
+  declare_uniface_fetch_all_algorithm<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
 }
 
 template <typename Tconfig, typename T>
@@ -342,11 +454,10 @@ void declare_uniface_class (py::module &m)
 				}
 			}
 
-			MPI_Comm comm;
 			MPI_Comm ric_mpiComm;
 
 			if (world.is_none()) {
-				comm = MPI_COMM_WORLD;
+				MPI_Comm comm = MPI_COMM_WORLD;
 				ric_mpiComm = reinterpret_cast<MPI_Comm>(comm);
 			} else {
 				PyObject *py_src = world.ptr();

--- a/wrappers/Python/mui4py/samplers.py
+++ b/wrappers/Python/mui4py/samplers.py
@@ -121,13 +121,12 @@ class SamplerSumQuintic(Sampler):
 
 
 class SamplerRbf(Sampler, CppClass):
-    def __init__(self, r, pointvect, basisFunc, conservative, polynomial,
-                 smoothFunc, cutoff, cgSolveTol, cgMaxIter, pouSize, precond, 
-                 mpiComm):
+    def __init__(self, r, pointvect, basisFunc, conservative, smoothFunc,
+                 writeMatrix, writeFileAddress, cutoff, cgSolveTol, cgMaxIter,
+                 pouSize, precond, mpiComm):
         super(SamplerRbf, self).__init__(args=(r, pointvect, basisFunc,
-                                         conservative, polynomial, smoothFunc,
-                                         cutoff, cgSolveTol, cgMaxIter, pouSize, precond, 
-                                         mpiComm))
+                                         conservative, smoothFunc, writeMatrix, writeFileAddress,
+                                         cutoff, cgSolveTol, cgMaxIter, pouSize, precond, mpiComm))
         self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
 
 # Temporal samplers

--- a/wrappers/Python/mui4py/temporal_samplers.py
+++ b/wrappers/Python/mui4py/temporal_samplers.py
@@ -38,10 +38,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.      #
 ##############################################################################
 #
-# @file samplers.py
+# @file temporal_sampler.py
 # @author E. R. Fernandez, W. Liu
-# @date 25 January 2019
-# @brief Sampler functions for the MUI Python wrapper.
+# @date 18 March 2019
+# @brief Temporal sampler functions for the MUI Python wrapper.
 #
 """
 
@@ -49,82 +49,41 @@ from mui4py.common import CppClass
 from mui4py.config import Config
 from mui4py.types import UINT, UINT32, UINT64, FLOAT, FLOAT32, FLOAT64, INT, INT32, INT64, STRING, BOOL
 
-# Interface for Sampler
+# Interface for TemporalSampler
 def sampler_fetch_signature(self):
     sig = self._split_class_name(title=False)
     sig = sig.replace("_sampler", "")
     return sig.replace("sampler_", "")
 
-
-# Spatial samplers
-class Sampler(CppClass):
+# Temporal samplers
+class TemporalSampler(CppClass):
     def __init__(self, args=(), kwargs={}):
         # Empty config to not trigger error in default config.
-        super(Sampler, self).__init__(Config(), args=args, kwargs=kwargs)
+        super(TemporalSampler, self).__init__(Config(), args, kwargs)
 
 
-Sampler.fetch_signature = sampler_fetch_signature
+TemporalSampler.fetch_signature = sampler_fetch_signature
 
 
-class SamplerExact(Sampler):
+class TemporalSamplerExact(TemporalSampler):
     def __init__(self, tol=None):
-        super(SamplerExact, self).__init__(kwargs={"tol": tol})
-        self._ALLOWED_IO_TYPES = [FLOAT, INT, INT32, INT64, UINT, UINT32, UINT64, FLOAT32, FLOAT64, STRING, BOOL]
+        super(TemporalSamplerExact, self).__init__(kwargs={"tol": tol})
+        self._ALLOWED_IO_TYPES = [INT, INT32, INT64, UINT, UINT32, UINT64, FLOAT, FLOAT32, FLOAT64, STRING, BOOL]
 
 
-class SamplerGauss(Sampler):
-    def __init__(self, r, h):
-        super(SamplerGauss, self).__init__(args=(r, h))
-        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
+class TemporalSamplerGauss(TemporalSampler):
+    def __init__(self, cutoff, sigma):
+        super(TemporalSamplerGauss, self).__init__(args=(cutoff, sigma))
+        self._ALLOWED_IO_TYPES = [UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]
 
 
-class SamplerMovingAverage(Sampler):
-    def __init__(self, bbox):
-        super(SamplerMovingAverage, self).__init__(args=(_Point(bbox), ))
-        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
+class TemporalSamplerMean(TemporalSampler):
+    def __init__(self, newleft=None, newright=None):
+        super(TemporalSamplerMean, self).__init__(kwargs={"newleft": newleft, "newright": newright})
+        self._ALLOWED_IO_TYPES = [UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]
 
 
-class SamplerNearestNeighbor(Sampler):
-    def __init__(self, r, h):
-        super(SamplerNearestNeighbor, self).__init__(args=(r, h))
-        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
-
-
-class SamplerPseudoNearest2Linear(Sampler):
-    def __init__(self, h):
-        super(SamplerPseudoNearest2Linear, self).__init__(args=(h, ))
-        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
-
-
-class SamplerPseudoNearestNeighbor(Sampler):
-    def __init__(self, h):
-        super(SamplerPseudoNearestNeighbor, self).__init__(args=(h,))
-        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
-
-
-class SamplerSherpardQuintic(Sampler):
-    def __init__(self, r):
-        super(SamplerSherpardQuintic, self).__init__(args=(r,))
-        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
-
-
-class SamplerSphQuintic(Sampler):
-    def __init__(self, r):
-        super(SamplerSphQuintic, self).__init__(args=(r,))
-        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
-
-
-class SamplerSumQuintic(Sampler):
-    def __init__(self, r):
-        super(SamplerSumQuintic, self).__init__(args=(r,))
-        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
-
-
-class SamplerRbf(Sampler, CppClass):
-    def __init__(self, r, pointvect, basisFunc, conservative, smoothFunc,
-                 writeMatrix, writeFileAddress, cutoff, cgSolveTol, cgMaxIter,
-                 pouSize, precond, mpiComm):
-        super(SamplerRbf, self).__init__(args=(r, pointvect, basisFunc,
-                                         conservative, smoothFunc, writeMatrix, writeFileAddress,
-                                         cutoff, cgSolveTol, cgMaxIter, pouSize, precond, mpiComm))
-        self._ALLOWED_IO_TYPES = [FLOAT, UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT32, FLOAT64]
+class TemporalSamplerSum(TemporalSampler):
+    def __init__(self, newleft=None, newright=None):
+        super(TemporalSamplerSum, self).__init__(kwargs={"newleft": newleft, "newright": newright})
+        self._ALLOWED_IO_TYPES = [UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]


### PR DESCRIPTION
# Fixed C++ RBF code
- Conservative mode works again
    The issue is with the `support()` function. By return `geometry::sphere<CONFIG>( focus, twor_ )`, the results does not conserved. Perhaps twor_ is not the proper measure. I changed it back to `geometry::any_shape<CONFIG>()` to ensure a correct result. 
- Fixed the RBF preconditioner by adding diagonal preconditioner.
   ILU, IC and SSOR are all `high standard`, `less robustness` preconditioners. The Css matrix in RBF cannot get conserved results by these three preconditioners. The robust diagonal preconditioner is implemented in MUI. After test, it works fine. The matrix generation time has reduced ~20% by using diagonal preconditioner compared with no preconditioner (not that much speedup though, implementing other robust preconditioners can be a future work). A warning here: after several testing, by using no preconditioner, we can get highly accurate results, but time consuming; by using diagonal preconditioner, we will lose some accuracy, but a bit faster on matrix generation.
- Update Python wrapper on RBF.